### PR TITLE
feat(collections): 完成合集插件核心功能与文章页合集导航

### DIFF
--- a/.changeset/collections-plugin.md
+++ b/.changeset/collections-plugin.md
@@ -1,0 +1,26 @@
+---
+"@cogita/plugin-collections": minor
+"@cogita/core": minor
+"@cogita/cli": minor
+"@cogita/theme-lucid": minor
+---
+
+feat(collections): 完成合集插件核心功能与文章页合集导航
+
+合集插件（@cogita/plugin-collections）实现完整功能：
+- 有序系列文章管理（frontmatter collection + order 字段）
+- 自动生成合集索引页和详情页路由
+- 虚拟模块 virtual-collections-data 暴露合集数据和辅助函数
+- 合集元数据覆盖（config.metadata 按 slug 索引）
+- 最小文章数阈值过滤（minPostCount）
+
+主题 lucid 集成：
+- 新增 Collection.tsx 布局（索引页卡片 + 详情页有序列表双模式）
+- 新增 CollectionNav.tsx 全局组件（文章页合集归属 + 上下篇导航）
+- 首页侧边栏展示合集列表
+- 完整 CSS 样式含响应式和暗色模式支持
+
+核心框架修复：
+- 修复 createThemePlugin 未传递 globalUIComponents 的 bug
+- 修复 globalStyles 路径截断 bug（?.[0] 取字符串首字符改为直接传递）
+- 新增 CLI preview 命令实现（之前为 TODO）

--- a/.workbuddy/memory/2026-08-06.md
+++ b/.workbuddy/memory/2026-08-06.md
@@ -1,0 +1,27 @@
+# 2026-08-06 工作日志
+
+## 合集插件（plugin-collections）设计文档
+
+### 背景
+tags 插件完成后，用户要求设计「合集」概念插件。合集 = 有序系列文章（类似书籍章节/播放列表），与 tags 的扁平无序标签互补。
+
+### 设计要点
+- **frontmatter 驱动**：文章声明 `collection: "slug"` + `order: N`
+- **一对多**：一篇文章归属一个合集（与 tags 多对多区分）
+- **有序**：按 order 排序，支持上一篇/下一篇导航
+- **元数据**：合集标题/描述/封面从 `cogita.config.ts` 的 `collections.metadata` 声明
+- **虚拟模块**：`virtual-collections-data` 暴露 allCollections/collectionMap/getCollectionBySlug/getCollectionByPostRoute
+- **页面**：`/collections` 索引页 + `/collections/:slug` 详情页（React 组件布局）
+- **主题布局**：CogitaTheme.pageLayouts 增加 collection/collectionIndex
+- **UI 组件**：CollectionList、OrderedPostList、CollectionNav、CollectionProgress
+- **首页侧边栏**：合集占位替换为 CollectionList compact 变体
+
+### 设计决策
+- D1：用 frontmatter 而非目录结构（灵活性、与 tags 一致）
+- D2：一篇文章只归属一个合集（保持系列连贯性）
+- D3：order 字段优先，无 order 按日期排序
+- D4：v1 元数据放配置，未来支持文件声明
+
+### 产出
+- `docs/plugins/plugin-collections-design.md` — 完整设计文档
+- `docs/plugins/README.md` — 更新插件列表（tags 标记完成，collections 设计中）

--- a/blog/cogita.config.ts
+++ b/blog/cogita.config.ts
@@ -37,6 +37,19 @@ export default defineConfig({
     minPostCount: 1,
   },
 
+  // 合集配置
+  collections: {
+    enabled: true,
+    routePrefix: 'collections',
+    metadata: {
+      'frontend-advanced': {
+        title: '前端进阶系列',
+        description: '从 React Hooks 到 TypeScript 类型系统，系统提升前端能力',
+      },
+    },
+    minPostCount: 1,
+  },
+
   themeConfig: {
     // 页脚配置 - 全局显示 RSS 订阅链接
     footer: {

--- a/blog/posts/react-hooks-best-practices.md
+++ b/blog/posts/react-hooks-best-practices.md
@@ -3,6 +3,9 @@ title: "React Hooks 最佳实践"
 date: "2025-01-01"
 tags: ["React", "JavaScript", "前端开发", "Hooks"]
 description: "深入探讨 React Hooks 的使用场景和最佳实践"
+collection: "frontend-advanced"
+order: 1
+collectionTitle: "React Hooks 实战指南"
 ---
 
 # React Hooks 最佳实践

--- a/blog/posts/typescript-advanced-types.md
+++ b/blog/posts/typescript-advanced-types.md
@@ -3,6 +3,9 @@ title: "TypeScript 高级类型系统"
 date: "2025-01-02"
 tags: ["TypeScript", "JavaScript", "类型系统", "前端开发"]
 description: "探索 TypeScript 高级类型特性和实际应用"
+collection: "frontend-advanced"
+order: 2
+collectionTitle: "TypeScript 类型体操"
 ---
 
 # TypeScript 高级类型系统

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -40,14 +40,9 @@
 | 插件名称 | 功能描述 | 状态 | 设计文档 |
 |---------|----------|------|----------|
 | `@cogita/plugin-posts-frontmatter` | 文章数据提取和路由生成 | ✅ 完成 | [设计文档](./plugin-posts-frontmatter-design.md) |
-
-### 🚧 开发中插件
-
-| 插件名称 | 功能描述 | 状态 | 设计文档 |
-|---------|----------|------|----------|
-| `@cogita/plugin-rss` | RSS/Atom/JSON Feed生成 | 📋 设计完成 | [设计文档](./plugin-rss-design.md) |
-| `@cogita/plugin-blog-list` | 博客列表和分页 | 📝 计划中 | - |
-| `@cogita/plugin-tags` | 标签系统 | 📝 计划中 | - |
+| `@cogita/plugin-rss` | RSS/Atom/JSON Feed 生成 | ✅ 完成 | [设计文档](./plugin-rss-design.md) |
+| `@cogita/plugin-tags` | 标签管理与标签云 | ✅ 完成 | [README](../../plugins/tags/README.md) |
+| `@cogita/plugin-collections` | 合集（系列文章）管理 | ✅ 完成 | [设计文档](./plugin-collections-design.md) |
 
 ### 📝 计划中插件
 
@@ -101,8 +96,8 @@ Cogita 插件系统
 ## 📊 插件开发统计
 
 ### 当前状态
-- **已发布插件**: 1个
-- **开发中插件**: 1个  
+- **已发布插件**: 4个
+- **开发中插件**: 0个  
 - **计划中插件**: 10+个
 - **社区插件**: 0个（期待你的贡献！）
 

--- a/docs/plugins/plugin-collections-design.md
+++ b/docs/plugins/plugin-collections-design.md
@@ -1,0 +1,391 @@
+# 合集插件架构设计与实现方案
+
+**文档版本**: 1.0  
+**创建日期**: 2026年8月  
+**插件名称**: `@cogita/plugin-collections`  
+**依赖**: `@cogita/plugin-posts-frontmatter`  
+**参考**: `@cogita/plugin-tags`（架构模式高度一致）
+
+## 概述
+
+合集（Collection）是 Cogita 博客系统中用于将多篇相关文章组织成**有序系列**的功能。与标签（Tags）的扁平、无序、多对多不同，合集强调**顺序性**和**系列感**——类似书籍的章节、课程的课时、或播放列表。
+
+### 核心区别：合集 vs 标签
+
+| 维度 | 标签 Tags | 合集 Collections |
+|------|----------|-----------------|
+| 关系模型 | 多对多（一篇文章多个标签） | 一对多（一篇文章归属一个合集） |
+| 排序 | 无序 | 有序（按 `order` 字段） |
+| 数据来源 | frontmatter `tags` 数组 | frontmatter `collection` + `order` |
+| 页面焦点 | 按标签筛选文章 | 按系列顺序阅读 |
+| 导航需求 | 无上下篇导航 | 需要「上一篇 / 下一篇」 |
+| 元数据 | 无（标签即名称） | 有（标题、描述、封面） |
+
+## 架构设计
+
+### 数据流
+
+```
+文章 frontmatter → 合集提取器 → 虚拟模块 → 主题组件渲染
+     ↓                ↓           ↓            ↓
+collection字段    分组+排序    virtual-     CollectionLayout
++ order字段       生成CollectionData  collections-data  CollectionList
+```
+
+### 插件结构
+
+```
+plugins/collections/
+├── src/
+│   ├── index.ts          # 插件入口，导出 pluginCollections
+│   ├── plugin.ts         # 插件工厂主逻辑
+│   ├── types.ts          # 类型定义（CollectionData, CollectionsConfig 等）
+│   ├── utils.ts          # 合集提取、排序、统计工具函数
+│   └── client.d.ts       # 虚拟模块类型声明
+├── package.json
+└── README.md
+```
+
+### 核心类型定义
+
+```typescript
+/**
+ * 合集数据结构
+ */
+export interface CollectionData {
+  /** 合集 slug（URL 标识） */
+  slug: string;
+  /** 合集标题（来自配置或从 slug 生成） */
+  title: string;
+  /** 合集描述 */
+  description?: string;
+  /** 封面图片路径 */
+  cover?: string;
+  /** 合集内的文章列表（已按 order 排序） */
+  posts: CollectionPost[];
+  /** 文章数量 */
+  count: number;
+  /** 合集页面路由 */
+  route: string;
+  /** 合集创建时间（首篇文章日期） */
+  createdDate?: string;
+  /** 合集更新时间（末篇文章日期） */
+  updatedDate?: string;
+}
+
+/**
+ * 合集内的文章引用（比 PostReference 多 order 字段）
+ */
+export interface CollectionPost {
+  title: string;
+  route: string;
+  createDate: string;
+  updateDate: string;
+  description?: string;
+  /** 在合集中的序号（从 1 开始） */
+  order: number;
+  /** 合集内的自定义标题（可选，覆盖文章原标题） */
+  collectionTitle?: string;
+}
+
+/**
+ * 合集插件配置
+ */
+export interface CollectionsConfig {
+  /** 是否启用，默认 true */
+  enabled?: boolean;
+  /** 路由前缀，默认 'collections' */
+  routePrefix?: string;
+  /** 合集元数据覆盖（按 slug 索引） */
+  metadata?: Record<string, CollectionMetadata>;
+  /** 排除的合集 slug 列表 */
+  excludeCollections?: string[];
+  /** 最小文章数阈值，默认 1 */
+  minPostCount?: number;
+}
+
+/**
+ * 合集元数据（用户在配置中声明）
+ */
+export interface CollectionMetadata {
+  title?: string;
+  description?: string;
+  cover?: string;
+}
+```
+
+### 文章 Frontmatter 声明方式
+
+```yaml
+---
+title: "React Hooks 入门"
+date: "2026-01-01"
+collection: "react-hooks-series"
+order: 1
+---
+
+# React Hooks 入门
+...
+```
+
+**字段说明：**
+
+- `collection`：合集 slug。同一 slug 的文章归入同一合集。
+- `order`：在合集中的排序序号（数字，升序）。未指定则按文章日期排序。
+- `collectionTitle`（可选）：合集内该篇的自定义标题，不指定则用文章 `title`。
+
+### 虚拟模块
+
+插件通过 `addRuntimeModules` 暴露 `virtual-collections-data`：
+
+```typescript
+declare module 'virtual-collections-data' {
+  export const allCollections: CollectionData[];
+  export const collectionMap: Record<string, CollectionData>;
+  export const collectionsConfig: CollectionsConfig;
+
+  export function getCollectionBySlug(slug: string): CollectionData | undefined;
+  export function getPostsByCollection(slug: string): CollectionPost[];
+  export function getCollectionByPostRoute(route: string): CollectionData | undefined;
+  export function getCollectionStats(): CollectionStats;
+}
+```
+
+**关键函数：**
+
+- `getCollectionByPostRoute(route)` — 给定文章路由，返回它所属的合集（用于文章页显示合集导航）
+- `getCollectionStats()` — 合集统计（总数、最大合集、平均文章数等）
+
+### 页面生成
+
+插件通过 `addPages` 生成以下页面（使用主题 React 布局组件）：
+
+| 路由 | 布局 | 内容 |
+|------|------|------|
+| `/collections` | `pageLayouts.collectionIndex` | 合集列表页：所有合集卡片 |
+| `/collections/:slug` | `pageLayouts.collection` | 合集详情页：有序文章列表 + 导航 |
+
+> **注意**：与 tags 插件一致，合集页面使用 React 组件布局。主题需在 `getThemeConfig()` 中声明 `pageLayouts.collection` 和 `pageLayouts.collectionIndex`。
+
+### 主题集成
+
+#### CogitaTheme 扩展
+
+```typescript
+// shared/src/index.ts — CogitaTheme.pageLayouts 增加：
+pageLayouts: {
+  home: string;
+  tag?: string;
+  tagIndex?: string;
+  collection?: string;        // 合集详情页布局
+  collectionIndex?: string;   // 合集索引页布局
+};
+```
+
+#### 主题布局组件（lucid 示例）
+
+```tsx
+// themes/lucid/src/layouts/Collection.tsx
+const CollectionLayout: React.FC<LayoutProps> = () => {
+  const pathname = decodeURIComponent(window.location.pathname);
+  const slug = pathname.split('/collections/')[1]?.replace(/\.html$/, '') || '';
+
+  if (!slug) {
+    // 索引页：所有合集卡片
+    return <CollectionList collections={allCollections} />;
+  }
+
+  // 详情页：有序文章列表
+  const collection = getCollectionBySlug(slug);
+  if (!collection) return <NotFound />;
+
+  return (
+    <div className="collection-page">
+      <CollectionHeader collection={collection} />
+      <OrderedPostList posts={collection.posts} />
+      <CollectionNav collection={collection} currentRoute={pathname} />
+    </div>
+  );
+};
+```
+
+### UI 组件
+
+新增到 `@cogita/ui`：
+
+| 组件 | 用途 | Props |
+|------|------|-------|
+| `CollectionList` | 合集卡片列表（索引页 + 首页侧边栏） | `collections`, `variant` ('card' \| 'compact') |
+| `OrderedPostList` | 有序文章列表（带序号） | `posts: CollectionPost[]` |
+| `CollectionNav` | 上一篇/下一篇导航 | `collection`, `currentRoute` |
+| `CollectionProgress` | 阅读进度指示器 | `current`, `total` |
+
+### 首页侧边栏集成
+
+Home.tsx 的合集占位区替换为 `CollectionList` compact 变体：
+
+```tsx
+<aside className="home-sidebar">
+  <section className="sidebar-section">
+    <h2 className="sidebar-title">标签</h2>
+    <TagCloud tags={allTags} config={tagsConfig.tagCloud} />
+  </section>
+  <section className="sidebar-section">
+    <h2 className="sidebar-title">合集</h2>
+    <CollectionList collections={allCollections} variant="compact" limit={5} />
+  </section>
+</aside>
+```
+
+## 配置示例
+
+### 基础配置（零配置开箱即用）
+
+```typescript
+// cogita.config.ts
+export default defineConfig({
+  collections: { enabled: true },
+  theme: 'lucid',  // 主题自动加载 collections 插件
+});
+```
+
+文章 frontmatter 只需声明 `collection` 和 `order`，合集标题自动从 slug 生成。
+
+### 完整配置（带元数据）
+
+```typescript
+export default defineConfig({
+  collections: {
+    enabled: true,
+    routePrefix: 'series',  // 使用 /series/react-hooks 而非 /collections/react-hooks
+    metadata: {
+      'react-hooks-series': {
+        title: 'React Hooks 深入系列',
+        description: '从入门到精通，系统掌握 React Hooks',
+        cover: '/images/covers/react-hooks.png',
+      },
+      'git-advanced': {
+        title: 'Git 进阶技巧',
+        description: 'Rebase、Cherry-pick、工作流实战',
+      },
+    },
+    minPostCount: 2,  // 少于 2 篇的合集不显示
+  },
+});
+```
+
+### 文章声明示例
+
+```yaml
+# posts/react-hooks-01.md
+---
+title: "React Hooks 入门"
+collection: "react-hooks-series"
+order: 1
+---
+
+# posts/react-hooks-02.md
+---
+title: "useEffect 深入解析"
+collection: "react-hooks-series"
+order: 2
+collectionTitle: "副作用与 Effect Hook"
+---
+
+# posts/react-hooks-03.md
+---
+title: "自定义 Hooks 模式"
+collection: "react-hooks-series"
+order: 3
+---
+```
+
+## 与 tags 插件的架构对比
+
+| 方面 | tags 插件 | collections 插件 |
+|------|----------|-----------------|
+| 数据提取 | `extractTagsFromPosts` | `extractCollectionsFromPosts` |
+| 分组逻辑 | 按 tag name 分组 | 按 collection slug 分组 |
+| 排序 | 无（或按 count） | 按 order 字段升序 |
+| 虚拟模块 | `virtual-tags-data` | `virtual-collections-data` |
+| 页面布局 | `pageLayouts.tag` | `pageLayouts.collection` |
+| UI 组件 | TagCloud, TagList | CollectionList, OrderedPostList |
+| 元数据来源 | 无 | config.metadata + 自动生成 |
+
+## 实现计划与进度
+
+### Phase 1：核心插件（MVP）✅ 已完成
+
+1. ✅ `plugins/collections/` 脚手架（package.json, tsconfig, rslib.config）
+2. ✅ `types.ts` — 类型定义
+3. ✅ `utils.ts` — `extractCollectionsFromPosts`、`processCollectionsFromPosts`、`calculateCollectionStats`
+4. ✅ `plugin.ts` — 工厂函数、`beforeBuild`、`addRuntimeModules`、`addPages`
+5. ✅ `client.d.ts` — 虚拟模块类型声明
+6. ✅ `shared/src/index.ts` — `CogitaTheme.pageLayouts` 增加 collection 字段
+7. ✅ `core/src/node/config.ts` — `createFullConfig` 增加 collections 默认配置
+
+### Phase 2：主题与 UI ✅ 已完成
+
+1. ✅ `themes/lucid/src/layouts/Collection.tsx` — 合集页面布局（索引页 + 详情页双模式）
+2. ✅ `themes/lucid/src/index.ts` — `pageLayouts` 声明 collection，注册 CollectionNav 全局组件
+3. ✅ Home.tsx 侧边栏合集列表（内联实现，非 @cogita/ui 组件）
+4. ✅ `themes/lucid/src/theme.css` — 合集页面样式 + 文章页合集导航样式 + 暗色模式
+
+> **注意**：UI 组件（CollectionList、OrderedPostList、CollectionNav）未抽取到 `@cogita/ui`，而是在主题布局中内联实现。这是因为合集 UI 与主题视觉强绑定，抽取为通用组件的收益不大。如未来出现第二个主题，可再考虑抽取。
+
+### Phase 3：增强功能（部分完成）
+
+#### ✅ 已完成：文章页合集导航
+
+- ✅ `themes/lucid/src/components/CollectionNav.tsx` — 全局 UI 组件
+- ✅ 通过 `globalUIComponents` 注册，在所有页面加载
+- ✅ 检测当前文章是否属于合集，显示合集归属信息 + 上下篇导航
+- ✅ 支持暗色模式、响应式设计
+- ✅ 修复了 `core/src/node/config.ts` 中 `globalUIComponents` 未传递的 bug
+
+#### ✅ 已完成：CLI preview 命令
+
+- ✅ `packages/core/src/node/preview.ts` — 新增 `createPreview` 函数
+- ✅ `packages/cli/src/index.ts` — `preview` 命令实现（之前是 TODO）
+- ✅ 支持 `--port` 参数
+
+#### 📐 未实现：后续增强
+
+- 📐 合集阅读进度持久化（localStorage）— 记录用户在合集内的阅读进度
+- 📐 合集封面图自动生成 — 为合集生成 OG 图片
+- 📐 合集 RSS 订阅 — 每个合集独立的 RSS feed
+
+### Bug 修复（开发过程中发现并修复）
+
+1. **`config.ts` globalUIComponents 未传递** — `createThemePlugin` 未将主题的 `globalUIComponents` 传递给 Rspress，导致全局组件不生效
+2. **`config.ts` globalStyles 路径截断** — `theme.globalStyles?.[0]` 对字符串取字符索引（得到 `/`），改为 `theme.globalStyles`
+3. **`Collection.tsx` 无效导航** — 合集详情页中 prev/next 导航用 `window.location.pathname` 匹配文章路由，但合集详情页 pathname 永远不匹配文章路由，导致导航永远不显示
+
+## 设计决策记录
+
+### D1：为什么用 frontmatter 而非目录结构？
+
+用户提到合集是「文件夹的概念」。但目录结构方式有以下问题：
+- 一篇文章只能在一个目录 → 无法跨合集
+- 移动文章需要移动文件 → 不灵活
+- 与现有 posts-frontmatter 插件的扁平扫描模式冲突
+
+**决策**：用 frontmatter `collection` 字段声明归属，保持与 tags 插件一致的架构。目录结构可作为未来增强（自动推断 collection slug）。
+
+### D2：为什么一篇文章只归属一个合集？
+
+合集强调「系列感」和顺序阅读。一篇文章同时属于多个合集会破坏这种连贯性，也让导航逻辑复杂化。
+
+**决策**：`collection` 字段为单个字符串。如需多合集，未来支持 `collections: ["a", "b"]` 数组形式。
+
+### D3：order 字段 vs 日期排序？
+
+`order` 字段显式可控，适合教程类系列。日期排序适合时间线类内容。
+
+**决策**：优先用 `order` 字段；未指定 order 的文章按 `createDate` 升序排在末尾。
+
+### D4：合集元数据放配置 vs 放文件？
+
+配置方式（`cogita.config.ts` 的 `metadata`）集中管理，适合少量合集。文件方式（如 `collections/react-hooks.md`）分散管理，适合大量合集。
+
+**决策**：v1 用配置方式。未来可支持在 posts 目录下放 `_collections/:slug.md` 文件声明元数据。

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createBuild, createServer } from '@cogita/core';
+import { createBuild, createPreview, createServer } from '@cogita/core';
 import { program } from 'commander';
 
 // Helper to find the package.json
@@ -44,9 +44,11 @@ program
 program
   .command('preview')
   .description('Preview the production build')
-  .action(() => {
-    console.log('Starting preview server...');
-    // TODO: Implement preview server
+  .option('-p, --port <port>', 'port number', '3030')
+  .action(async (options: { port: string }) => {
+    const port = Number.parseInt(options.port, 10);
+    console.log(`Starting preview server on port ${port}...`);
+    await createPreview(CWD, port);
   });
 
 program.parse(process.argv);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './config';
 export * from './node/config';
 export * from './node/dev';
 export * from './node/build';
+export * from './node/preview';

--- a/packages/core/src/node/config.ts
+++ b/packages/core/src/node/config.ts
@@ -97,7 +97,9 @@ function createThemePlugin(theme: CogitaTheme): RspressPlugin {
   return {
     name: 'cogita-theme-plugin',
     // 注入主题全局样式（theme.css），让首页/tag页等自定义布局样式生效
-    globalStyles: theme.globalStyles?.[0],
+    globalStyles: theme.globalStyles,
+    // 注册主题的全局 UI 组件（如 Footer、合集导航等），使其在所有页面生效
+    globalUIComponents: theme.globalUIComponents ?? [],
     addPages: async () => {
       if (!theme.pageLayouts.home) {
         return [];

--- a/packages/core/src/node/preview.ts
+++ b/packages/core/src/node/preview.ts
@@ -1,0 +1,17 @@
+import { serve } from '@rspress/core';
+import { createRspressConfig, loadCogitaConfig } from './config';
+
+/**
+ * 预览构建产物
+ * @param root 项目根目录
+ * @param port 预览端口
+ */
+export async function createPreview(root: string, port?: number): Promise<void> {
+  const cogitaConfig = await loadCogitaConfig(root);
+  const rspressConfig = await createRspressConfig(cogitaConfig, root);
+
+  await serve({
+    config: rspressConfig,
+    port,
+  });
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,6 +79,37 @@ export interface TagsConfig {
    */
   minPostCount?: number;
 }
+
+/**
+ * Collections plugin configuration
+ */
+export interface CollectionsConfig {
+  /**
+   * Enable collections functionality
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Route prefix for collection pages
+   * @default 'collections'
+   */
+  routePrefix?: string;
+  /**
+   * Collection metadata overrides (indexed by slug)
+   */
+  metadata?: Record<string, { title?: string; description?: string; cover?: string }>;
+  /**
+   * Collection slugs to exclude
+   * @default []
+   */
+  excludeCollections?: string[];
+  /**
+   * Minimum post count threshold
+   * @default 1
+   */
+  minPostCount?: number;
+}
+
 export interface RSSConfig {
   /**
    * Feed title
@@ -161,6 +192,11 @@ export interface CogitaConfig {
    * Tags plugin configuration
    */
   tags?: TagsConfig;
+
+  /**
+   * Collections plugin configuration
+   */
+  collections?: CollectionsConfig;
 
   /**
    * RSS feed configuration

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,6 +54,14 @@ export interface CogitaPluginConfig {
     minPostCount?: number;
     [key: string]: unknown;
   };
+  collections?: {
+    enabled?: boolean;
+    routePrefix?: string;
+    metadata?: Record<string, { title?: string; description?: string; cover?: string }>;
+    excludeCollections?: string[];
+    minPostCount?: number;
+    [key: string]: unknown;
+  };
   _framework?: {
     version: string;
     buildTime: string;
@@ -80,9 +88,13 @@ export interface CogitaTheme {
     tag?: string;
     /** 标签索引页布局（路由 /tags） */
     tagIndex?: string;
+    /** 合集详情页布局（路由 /collections/:slug） */
+    collection?: string;
+    /** 合集索引页布局（路由 /collections） */
+    collectionIndex?: string;
     [key: string]: string | undefined;
   };
-  globalStyles?: string[];
+  globalStyles?: string;
   globalUIComponents?: (string | [string, object])[];
   plugins?: CogitaPluginFactory[];
 }

--- a/plugins/collections/LICENSE
+++ b/plugins/collections/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 wu9o
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/collections/README.md
+++ b/plugins/collections/README.md
@@ -1,0 +1,86 @@
+# @cogita/plugin-collections
+
+合集（Collection）插件，为 Cogita 博客提供有序系列文章管理、合集页面生成和导航功能。
+
+## 功能特性
+
+- **有序系列文章**：将多篇相关文章组织成有顺序的合集（类似书籍章节、课程课时）
+- **自动页面生成**：自动生成合集索引页和合集详情页
+- **文章页合集导航**：在文章详情页显示"本文是合集 X 的第 N 篇"及上下篇导航
+- **虚拟模块**：通过 `virtual-collections-data` 暴露合集数据和辅助函数
+- **元数据覆盖**：支持在配置中为合集设置自定义标题、描述和封面
+- **零配置开箱即用**：文章 frontmatter 只需声明 `collection` 和 `order` 字段
+
+## 安装
+
+该插件作为 `@cogita/theme-lucid` 的依赖自动安装，无需手动安装。
+
+## 配置
+
+在 `cogita.config.ts` 中配置：
+
+```typescript
+export default defineConfig({
+  collections: {
+    enabled: true,
+    routePrefix: 'collections',
+    metadata: {
+      'react-hooks-series': {
+        title: 'React Hooks 深入系列',
+        description: '从入门到精通，系统掌握 React Hooks',
+      },
+    },
+    minPostCount: 1,
+  },
+  theme: 'lucid',
+});
+```
+
+### 配置选项
+
+| 选项 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `enabled` | `boolean` | `true` | 是否启用合集功能 |
+| `routePrefix` | `string` | `'collections'` | 合集页面路由前缀 |
+| `metadata` | `Record<string, CollectionMetadata>` | `{}` | 合集元数据覆盖（按 slug 索引） |
+| `excludeCollections` | `string[]` | `[]` | 排除的合集 slug 列表 |
+| `minPostCount` | `number` | `1` | 最小文章数阈值 |
+
+## 文章 Frontmatter
+
+在文章的 frontmatter 中声明合集归属：
+
+```yaml
+---
+title: "React Hooks 入门"
+collection: "react-hooks-series"
+order: 1
+collectionTitle: "React Hooks 实战指南"
+---
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `collection` | `string` | 合集 slug，同一 slug 的文章归入同一合集 |
+| `order` | `number` | 在合集中的排序序号（升序），未指定则按日期排序 |
+| `collectionTitle` | `string` | 合集内该篇的自定义标题（可选，覆盖文章原标题） |
+
+## 虚拟模块
+
+插件通过 `addRuntimeModules` 暴露 `virtual-collections-data`：
+
+```typescript
+import {
+  allCollections,
+  collectionMap,
+  collectionsConfig,
+  collectionStats,
+  getCollectionBySlug,
+  getPostsByCollection,
+  getCollectionByPostRoute,
+} from 'virtual-collections-data';
+```
+
+## 许可证
+
+MIT

--- a/plugins/collections/client.d.ts
+++ b/plugins/collections/client.d.ts
@@ -1,0 +1,31 @@
+// 客户端虚拟模块类型声明
+// 注意：声明必须与 plugin.ts 的 addRuntimeModules 实际导出保持一致
+declare module 'virtual-collections-data' {
+  import type {
+    CollectionData,
+    CollectionPost,
+    CollectionsConfig,
+    CollectionStats,
+  } from '@cogita/plugin-collections';
+
+  /** 所有合集数据 */
+  export const allCollections: CollectionData[];
+
+  /** 合集映射表（按 slug 索引） */
+  export const collectionMap: Record<string, CollectionData>;
+
+  /** 合集配置 */
+  export const collectionsConfig: Required<CollectionsConfig>;
+
+  /** 合集统计数据 */
+  export const collectionStats: CollectionStats;
+
+  /** 根据 slug 获取合集 */
+  export function getCollectionBySlug(slug: string): CollectionData | undefined;
+
+  /** 根据合集 slug 获取文章列表 */
+  export function getPostsByCollection(slug: string): CollectionPost[];
+
+  /** 根据文章路由获取它所属的合集 */
+  export function getCollectionByPostRoute(route: string): CollectionData | undefined;
+}

--- a/plugins/collections/package.json
+++ b/plugins/collections/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@cogita/plugin-collections",
+  "version": "0.0.1",
+  "description": "合集插件，为 Cogita 博客提供有序系列文章管理、合集页面生成和导航功能。",
+  "keywords": [
+    "cogita",
+    "plugin",
+    "collections",
+    "series",
+    "blog",
+    "static-site-generator",
+    "rspress",
+    "content-organization"
+  ],
+  "author": "wu9o <https://github.com/wu9o>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wu9o/cogita.git",
+    "directory": "plugins/collections"
+  },
+  "bugs": {
+    "url": "https://github.com/wu9o/cogita/issues"
+  },
+  "homepage": "https://github.com/wu9o/cogita/tree/main/plugins/collections#readme",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "client.d.ts", "README.md", "LICENSE"],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "rslib build",
+    "dev": "rslib build -w",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@cogita/shared": "workspace:*",
+    "@rslib/core": "0.11.2",
+    "@types/glob": "^8.1.0",
+    "rsbuild-plugin-publint": "^0.3.3",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "@rspress/core": "^1.45.1",
+    "glob": "^11.0.0"
+  },
+  "peerDependencies": {
+    "@cogita/plugin-posts-frontmatter": "workspace:*"
+  }
+}

--- a/plugins/collections/rslib.config.ts
+++ b/plugins/collections/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
+
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      dts: true,
+      format: 'esm',
+      output: {
+        distPath: {
+          root: './dist',
+        },
+      },
+    },
+  ],
+  plugins: [pluginPublint()],
+});

--- a/plugins/collections/src/index.ts
+++ b/plugins/collections/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Collections 插件导出文件
+ */
+
+// 导出插件工厂函数
+export { pluginCollections } from './plugin';
+
+// 导出类型定义
+export type {
+  CollectionData,
+  CollectionPost,
+  CollectionMetadata,
+  CollectionsConfig,
+  CollectionStats,
+} from './types';
+
+// 导出工具函数（高级用法）
+export {
+  extractCollectionsFromPosts,
+  processCollectionsFromPosts,
+  calculateCollectionStats,
+} from './utils';
+
+// 默认导出
+export { pluginCollections as default } from './plugin';

--- a/plugins/collections/src/plugin.ts
+++ b/plugins/collections/src/plugin.ts
@@ -1,0 +1,128 @@
+import type { CogitaPluginConfig } from '@cogita/shared';
+import type { RspressPlugin } from '@rspress/core';
+import type { CollectionData, CollectionStats, CollectionsConfig } from './types';
+import {
+  calculateCollectionStats,
+  extractCollectionsFromPosts,
+  processCollectionsFromPosts,
+} from './utils';
+
+export function pluginCollections(config: CogitaPluginConfig): RspressPlugin | null {
+  const collectionsConfig = config.collections;
+
+  // 未配置或明确禁用则跳过
+  if (!collectionsConfig || collectionsConfig.enabled === false) {
+    console.log('[Collections Plugin] Collections 配置未启用，跳过合集功能');
+    return null;
+  }
+
+  // 创建完整配置，应用默认值
+  const finalCollectionsConfig: Required<CollectionsConfig> = {
+    enabled: true,
+    routePrefix: collectionsConfig.routePrefix ?? 'collections',
+    metadata: collectionsConfig.metadata ?? {},
+    excludeCollections: collectionsConfig.excludeCollections ?? [],
+    minPostCount: collectionsConfig.minPostCount ?? 1,
+  };
+
+  // 插件内部状态
+  let allCollectionsData: CollectionData[] = [];
+  let collectionMap: Map<string, CollectionData> = new Map();
+  let collectionStats: CollectionStats = {} as CollectionStats;
+
+  return {
+    name: '@cogita/plugin-collections',
+
+    async beforeBuild() {
+      console.log('[Collections Plugin] 开始初始化合集插件...');
+
+      try {
+        const postsConfig = config.posts || {};
+        const postsDir = postsConfig.dir || 'posts';
+        const cwd = config.cwd || process.cwd();
+        const routePrefix = postsConfig.routePrefix || 'posts';
+
+        console.log(`[Collections Plugin] 扫描文章目录: ${postsDir}`);
+
+        const postsData = await extractCollectionsFromPosts(postsDir, cwd, routePrefix);
+
+        const { collectionsData, collectionsMap } = processCollectionsFromPosts(
+          postsData,
+          finalCollectionsConfig
+        );
+
+        allCollectionsData = collectionsData;
+        collectionMap = collectionsMap;
+        collectionStats = calculateCollectionStats(collectionsData);
+
+        console.log(
+          `[Collections Plugin] 成功处理 ${allCollectionsData.length} 个合集，来自 ${postsData.length} 篇文章`
+        );
+        if (collectionStats.largest) {
+          console.log(
+            `[Collections Plugin] 最大合集: ${collectionStats.largest.title} (${collectionStats.largest.count} 篇文章)`
+          );
+        }
+      } catch (error) {
+        console.error('[Collections Plugin] 初始化失败:', error);
+      }
+    },
+
+    addRuntimeModules() {
+      return {
+        'virtual-collections-data': `
+          export const allCollections = ${JSON.stringify(allCollectionsData)};
+          export const collectionMap = ${JSON.stringify(Object.fromEntries(collectionMap))};
+          export const collectionsConfig = ${JSON.stringify(finalCollectionsConfig)};
+          export const collectionStats = ${JSON.stringify(collectionStats)};
+
+          export function getCollectionBySlug(slug) {
+            return allCollections.find(c => c.slug === slug);
+          }
+
+          export function getPostsByCollection(slug) {
+            const collection = collectionMap[slug];
+            return collection ? collection.posts : [];
+          }
+
+          export function getCollectionByPostRoute(route) {
+            return allCollections.find(c => c.posts.some(p => p.route === route));
+          }
+        `,
+      };
+    },
+
+    async addPages() {
+      const collectionLayout = config.themeLayouts?.collection;
+
+      if (!collectionLayout) {
+        console.warn(
+          '[Collections Plugin] 主题未提供 pageLayouts.collection，跳过合集页面生成。' +
+            '请在主题 getThemeConfig() 中声明 pageLayouts.collection 以启用合集页面。'
+        );
+        return [];
+      }
+
+      const pages = [];
+
+      // 1. 合集索引页 (/collections)
+      pages.push({
+        routePath: `/${finalCollectionsConfig.routePrefix}`,
+        content: '---\npageType: collectionIndex\nsidebar: false\n---',
+        filepath: collectionLayout,
+      });
+
+      // 2. 每个合集的详情页 (/collections/:slug)
+      for (const collection of allCollectionsData) {
+        pages.push({
+          routePath: collection.route,
+          content: '---\npageType: collection\nsidebar: false\n---',
+          filepath: collectionLayout,
+        });
+      }
+
+      console.log(`[Collections Plugin] 生成 ${pages.length} 个合集页面`);
+      return pages;
+    },
+  };
+}

--- a/plugins/collections/src/types.ts
+++ b/plugins/collections/src/types.ts
@@ -1,0 +1,85 @@
+/**
+ * 合集内的文章引用（比普通文章引用多 order 字段）
+ */
+export interface CollectionPost {
+  /** 文章标题 */
+  title: string;
+  /** 文章路由 */
+  route: string;
+  /** 创建日期 */
+  createDate: string;
+  /** 更新日期 */
+  updateDate: string;
+  /** 文章描述 */
+  description?: string;
+  /** 在合集中的序号（从 1 开始） */
+  order: number;
+  /** 合集内的自定义标题（可选，覆盖文章原标题） */
+  collectionTitle?: string;
+}
+
+/**
+ * 合集数据结构
+ */
+export interface CollectionData {
+  /** 合集 slug（URL 标识） */
+  slug: string;
+  /** 合集标题 */
+  title: string;
+  /** 合集描述 */
+  description?: string;
+  /** 封面图片路径 */
+  cover?: string;
+  /** 合集内的文章列表（已按 order 排序） */
+  posts: CollectionPost[];
+  /** 文章数量 */
+  count: number;
+  /** 合集页面路由 */
+  route: string;
+  /** 合集创建时间（首篇文章日期） */
+  createdDate?: string;
+  /** 合集更新时间（末篇文章日期） */
+  updatedDate?: string;
+}
+
+/**
+ * 合集元数据（用户在配置中声明，按 slug 索引）
+ */
+export interface CollectionMetadata {
+  /** 合集标题 */
+  title?: string;
+  /** 合集描述 */
+  description?: string;
+  /** 封面图片路径 */
+  cover?: string;
+}
+
+/**
+ * 合集插件配置
+ */
+export interface CollectionsConfig {
+  /** 是否启用，默认 true */
+  enabled?: boolean;
+  /** 路由前缀，默认 'collections' */
+  routePrefix?: string;
+  /** 合集元数据覆盖（按 slug 索引） */
+  metadata?: Record<string, CollectionMetadata>;
+  /** 排除的合集 slug 列表 */
+  excludeCollections?: string[];
+  /** 最小文章数阈值，默认 1 */
+  minPostCount?: number;
+}
+
+/**
+ * 合集统计数据
+ */
+export interface CollectionStats {
+  /** 总合集数 */
+  totalCollections: number;
+  /** 文章最多的合集 */
+  largest: CollectionData;
+  /** 最新更新的合集 */
+  newest: CollectionData;
+  /** 平均每个合集的文章数 */
+  averagePostsPerCollection: number;
+}

--- a/plugins/collections/src/utils.ts
+++ b/plugins/collections/src/utils.ts
@@ -1,0 +1,172 @@
+import { getFrontmatterFromFile } from '@cogita/plugin-posts-frontmatter';
+import type { PostFrontmatter } from '@cogita/plugin-posts-frontmatter';
+import { glob } from 'glob';
+import type {
+  CollectionData,
+  CollectionMetadata,
+  CollectionPost,
+  CollectionStats,
+  CollectionsConfig,
+} from './types';
+
+/**
+ * 从文章中提取合集信息（复用 posts-frontmatter 的扫描逻辑）
+ * @param postsDir 文章目录
+ * @param cwd 当前工作目录
+ * @param routePrefix 路由前缀
+ * @returns 文章数据数组
+ */
+export async function extractCollectionsFromPosts(
+  postsDir: string,
+  cwd: string,
+  routePrefix = 'posts'
+): Promise<PostFrontmatter[]> {
+  const options = {
+    absolute: true,
+    cwd,
+    nodir: true,
+  };
+
+  const absolutePaths = await glob(`${postsDir}/**/*.{md,mdx}`, options);
+
+  return absolutePaths
+    .map((filePath) => {
+      try {
+        return getFrontmatterFromFile(filePath, postsDir, routePrefix);
+      } catch (error) {
+        console.warn(`[Collections Plugin] 跳过文件 ${filePath}:`, error);
+        return null;
+      }
+    })
+    .filter((f): f is PostFrontmatter => f !== null);
+}
+
+/**
+ * 从文章数据中处理合集
+ * @param postsData 文章数据数组
+ * @param config 合集配置
+ * @returns 合集数据数组和映射表
+ */
+export function processCollectionsFromPosts(
+  postsData: PostFrontmatter[],
+  config: Required<CollectionsConfig>
+): { collectionsData: CollectionData[]; collectionsMap: Map<string, CollectionData> } {
+  const collectionsMap = new Map<string, CollectionData>();
+
+  console.log(`[Collections Plugin] 开始处理 ${postsData.length} 篇文章的合集数据`);
+
+  // 遍历所有文章，按 collection 字段分组
+  for (const post of postsData) {
+    if (!post.collection) continue;
+
+    const slug = post.collection;
+
+    // 跳过排除的合集
+    if (config.excludeCollections.includes(slug)) continue;
+
+    const route = `/${config.routePrefix}/${slug}`;
+
+    // 创建合集内的文章引用
+    const collectionPost: CollectionPost = {
+      title: post.title,
+      route: post.route,
+      createDate: post.createDate,
+      updateDate: post.updateDate,
+      description: post.description,
+      order: post.order ?? 0,
+      collectionTitle: post.collectionTitle,
+    };
+
+    // 更新或创建合集
+    const existing = collectionsMap.get(slug);
+    if (existing) {
+      existing.posts.push(collectionPost);
+    } else {
+      // 从配置元数据获取标题/描述/封面
+      const meta: CollectionMetadata | undefined = config.metadata?.[slug];
+      collectionsMap.set(slug, {
+        slug,
+        title: meta?.title || slug,
+        description: meta?.description,
+        cover: meta?.cover,
+        posts: [collectionPost],
+        count: 0,
+        route,
+      });
+    }
+  }
+
+  // 过滤少于最小文章数量的合集
+  for (const [slug, collection] of collectionsMap.entries()) {
+    if (collection.posts.length < config.minPostCount) {
+      collectionsMap.delete(slug);
+    }
+  }
+
+  // 对每个合集的文章排序：有 order 的按 order 升序，无 order 的按日期升序排在末尾
+  for (const collection of collectionsMap.values()) {
+    collection.posts.sort((a, b) => {
+      // 两个都有 order → 按 order
+      if (a.order > 0 && b.order > 0) return a.order - b.order;
+      // 一个有 order 一个没有 → 有 order 的在前
+      if (a.order > 0) return -1;
+      if (b.order > 0) return 1;
+      // 都没有 → 按日期升序
+      return new Date(a.createDate).getTime() - new Date(b.createDate).getTime();
+    });
+
+    // 重新编号 order（从 1 开始）
+    collection.posts.forEach((post, index) => {
+      post.order = index + 1;
+    });
+
+    // 更新 count 和日期范围
+    collection.count = collection.posts.length;
+    collection.createdDate = collection.posts[0]?.createDate;
+    collection.updatedDate = collection.posts[collection.posts.length - 1]?.createDate;
+  }
+
+  // 转换为数组，按文章数量降序排列
+  const collectionsData = Array.from(collectionsMap.values()).sort((a, b) => b.count - a.count);
+
+  console.log(`[Collections Plugin] 处理完成，共 ${collectionsData.length} 个合集`);
+
+  return { collectionsData, collectionsMap };
+}
+
+/**
+ * 计算合集统计数据
+ * @param collectionsData 合集数据
+ * @returns 统计信息
+ */
+export function calculateCollectionStats(collectionsData: CollectionData[]): CollectionStats {
+  if (collectionsData.length === 0) {
+    return {
+      totalCollections: 0,
+      largest: {} as CollectionData,
+      newest: {} as CollectionData,
+      averagePostsPerCollection: 0,
+    };
+  }
+
+  // 文章最多的合集
+  const largest = collectionsData.reduce((prev, current) =>
+    prev.count > current.count ? prev : current
+  );
+
+  // 最新更新的合集
+  const newest = collectionsData.reduce((prev, current) => {
+    const prevDate = new Date(prev.updatedDate || 0);
+    const currentDate = new Date(current.updatedDate || 0);
+    return currentDate > prevDate ? current : prev;
+  });
+
+  const totalPosts = collectionsData.reduce((sum, c) => sum + c.count, 0);
+
+  return {
+    totalCollections: collectionsData.length,
+    largest,
+    newest,
+    averagePostsPerCollection: totalPosts / collectionsData.length,
+  };
+}

--- a/plugins/collections/tsconfig.json
+++ b/plugins/collections/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/posts-frontmatter/src/types.ts
+++ b/plugins/posts-frontmatter/src/types.ts
@@ -10,6 +10,12 @@ export interface PostFrontmatter {
   updateDate: string;
   categories?: string[];
   tags?: string[];
+  /** 合集 slug（声明文章归属的合集） */
+  collection?: string;
+  /** 在合集中的排序序号（升序） */
+  order?: number;
+  /** 合集内的自定义标题（可选，覆盖文章原标题） */
+  collectionTitle?: string;
   url: string;
 }
 

--- a/plugins/posts-frontmatter/src/utils.ts
+++ b/plugins/posts-frontmatter/src/utils.ts
@@ -42,6 +42,9 @@ export function getFrontmatterFromFile(
       updateDate: frontmatter.updateDate || stats.mtime.toISOString(),
       categories: frontmatter.categories,
       tags: frontmatter.tags,
+      collection: frontmatter.collection,
+      order: frontmatter.order,
+      collectionTitle: frontmatter.collectionTitle,
       url: '',
     };
   } catch (e) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,34 @@ importers:
         specifier: ^5.0.4
         version: 5.9.2
 
+  plugins/collections:
+    dependencies:
+      '@cogita/plugin-posts-frontmatter':
+        specifier: workspace:*
+        version: link:../posts-frontmatter
+      '@rspress/core':
+        specifier: ^1.45.1
+        version: 1.45.1(webpack@5.101.2)
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.3
+    devDependencies:
+      '@cogita/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@rslib/core':
+        specifier: 0.11.2
+        version: 0.11.2(@microsoft/api-extractor@7.52.10(@types/node@24.3.0))(typescript@5.9.2)
+      '@types/glob':
+        specifier: ^8.1.0
+        version: 8.1.0
+      rsbuild-plugin-publint:
+        specifier: ^0.3.3
+        version: 0.3.3(@rsbuild/core@1.4.15)
+      typescript:
+        specifier: ^5.0.4
+        version: 5.9.2
+
   plugins/posts-frontmatter:
     dependencies:
       '@rspress/core':
@@ -294,6 +322,9 @@ importers:
 
   themes/lucid:
     dependencies:
+      '@cogita/plugin-collections':
+        specifier: workspace:*
+        version: link:../../plugins/collections
       '@cogita/plugin-posts-frontmatter':
         specifier: workspace:*
         version: link:../../plugins/posts-frontmatter
@@ -2097,6 +2128,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:

--- a/themes/lucid/package.json
+++ b/themes/lucid/package.json
@@ -66,6 +66,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@cogita/plugin-collections": "workspace:*",
     "@cogita/plugin-posts-frontmatter": "workspace:*",
     "@cogita/plugin-rss": "workspace:*",
     "@cogita/plugin-tags": "workspace:*",

--- a/themes/lucid/src/components/CollectionNav.tsx
+++ b/themes/lucid/src/components/CollectionNav.tsx
@@ -1,0 +1,81 @@
+import { usePageData } from '@rspress/runtime';
+import { getCollectionByPostRoute } from 'virtual-collections-data';
+
+/**
+ * 文章详情页合集导航组件
+ *
+ * 通过 globalUIComponents 注册到所有页面，仅在文章属于某个合集时渲染：
+ * - 合集归属提示（"本文是《合集标题》系列的第 N 篇"）
+ * - 上一篇/下一篇导航链接
+ * - 阅读进度指示器（第 N/M 篇）
+ */
+export default function CollectionNav() {
+  const pageData = usePageData();
+  const base = (pageData?.siteData?.base || '').replace(/\/$/, '');
+
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
+
+  // 去除 base 前缀和 .html 后缀，获取文章路由
+  let articleRoute = pathname;
+  if (base && articleRoute.startsWith(base)) {
+    articleRoute = articleRoute.slice(base.length);
+  }
+  articleRoute = articleRoute.replace(/\.html$/, '').replace(/\/$/, '');
+
+  // 查找文章所属合集
+  const collection = getCollectionByPostRoute(articleRoute);
+  if (!collection) return null;
+
+  // 找当前文章在合集中的位置
+  const currentIndex = collection.posts.findIndex((p) => p.route === articleRoute);
+  if (currentIndex === -1) return null;
+
+  const prevPost = currentIndex > 0 ? collection.posts[currentIndex - 1] : null;
+  const nextPost =
+    currentIndex < collection.posts.length - 1 ? collection.posts[currentIndex + 1] : null;
+
+  const collectionsHref = `${base}/collections`;
+  const collectionHref = `${base}${collection.route}`;
+
+  return (
+    <div className="article-collection-nav">
+      <div className="collection-nav-info">
+        <a href={collectionHref} className="collection-nav-link">
+          {collection.title}
+        </a>
+        <span className="collection-nav-progress">
+          第 {currentIndex + 1} / {collection.count} 篇
+        </span>
+      </div>
+      {(prevPost || nextPost) && (
+        <nav className="collection-nav-buttons">
+          {prevPost ? (
+            <a href={`${base}${prevPost.route}`} className="collection-nav-btn collection-nav-prev">
+              <span className="collection-nav-btn-label">上一篇</span>
+              <span className="collection-nav-btn-title">
+                {prevPost.collectionTitle || prevPost.title}
+              </span>
+            </a>
+          ) : (
+            <span className="collection-nav-btn collection-nav-btn-placeholder" />
+          )}
+          {nextPost ? (
+            <a href={`${base}${nextPost.route}`} className="collection-nav-btn collection-nav-next">
+              <span className="collection-nav-btn-label">下一篇</span>
+              <span className="collection-nav-btn-title">
+                {nextPost.collectionTitle || nextPost.title}
+              </span>
+            </a>
+          ) : (
+            <span className="collection-nav-btn collection-nav-btn-placeholder" />
+          )}
+        </nav>
+      )}
+      <div className="collection-nav-breadcrumb">
+        <a href={collectionsHref}>全部合集</a>
+        <span className="separator">/</span>
+        <a href={collectionHref}>{collection.title}</a>
+      </div>
+    </div>
+  );
+}

--- a/themes/lucid/src/index.ts
+++ b/themes/lucid/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { pluginCollections } from '@cogita/plugin-collections';
 import { pluginPostsFrontmatter } from '@cogita/plugin-posts-frontmatter';
 import { pluginRSS } from '@cogita/plugin-rss';
 import { pluginTags } from '@cogita/plugin-tags';
@@ -36,13 +37,17 @@ export function getThemeConfig(): CogitaTheme {
     pageLayouts: {
       home: './layouts/Home.js',
       tag: './layouts/Tag.js',
+      collection: './layouts/Collection.js',
     },
 
     // 主题样式（会通过 cogita-theme-plugin 自动加载）
-    globalStyles: [path.resolve(__dirname, './theme.css')],
+    globalStyles: path.resolve(__dirname, './theme.css'),
 
     // 全局 UI 组件（会通过 cogita-theme-plugin 自动注册）
-    globalUIComponents: [path.resolve(__dirname, './components/Footer.js')],
+    globalUIComponents: [
+      path.resolve(__dirname, './components/Footer.js'),
+      path.resolve(__dirname, './components/CollectionNav.js'),
+    ],
 
     // ============================================
     // 功能插件（可选、可配置）
@@ -54,7 +59,12 @@ export function getThemeConfig(): CogitaTheme {
 
       // RSS feed 生成插件
       pluginRSS,
+
+      // 标签管理插件
       pluginTags,
+
+      // 合集（系列文章）插件
+      pluginCollections,
     ],
   };
 }

--- a/themes/lucid/src/layouts/Collection.tsx
+++ b/themes/lucid/src/layouts/Collection.tsx
@@ -1,0 +1,114 @@
+import type { LayoutProps } from '@cogita/shared';
+import { usePageData } from '@rspress/runtime';
+import type React from 'react';
+import { allCollections, getCollectionBySlug } from 'virtual-collections-data';
+
+/**
+ * 合集页面布局（索引页 + 详情页共用）
+ * 消费 virtual-collections-data 虚拟模块，根据当前 URL 路径判断渲染哪种页面：
+ * - /collections（无 slug）→ 合集索引页：所有合集卡片
+ * - /collections/:slug → 合集详情页：有序文章列表 + 上一篇/下一篇导航
+ */
+const CollectionPageLayout: React.FC<LayoutProps> = () => {
+  const pageData = usePageData();
+  const base = (pageData?.siteData?.base || '').replace(/\/$/, '');
+  const collectionsHref = `${base}/collections`;
+
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
+  const rawSlug =
+    pathname
+      .split('/collections/')[1]
+      ?.replace(/\.html$/, '')
+      .replace(/\/$/, '') || '';
+  const slug = decodeURIComponent(rawSlug);
+
+  // 索引页：无 slug，展示所有合集
+  if (!slug) {
+    return (
+      <div className="collection-page">
+        <header className="collection-header">
+          <h1 className="collection-title">合集</h1>
+          <p className="collection-meta">共 {allCollections.length} 个合集</p>
+        </header>
+        <section className="collection-list-section">
+          {allCollections.length === 0 ? (
+            <p className="collection-empty">暂无合集</p>
+          ) : (
+            <div className="collection-cards">
+              {allCollections.map((collection) => (
+                <a
+                  key={collection.slug}
+                  href={`${base}${collection.route}`}
+                  className="collection-card"
+                >
+                  <h3 className="collection-card-title">{collection.title}</h3>
+                  {collection.description && (
+                    <p className="collection-card-desc">{collection.description}</p>
+                  )}
+                  <p className="collection-card-meta">
+                    {collection.count} 篇文章
+                    {collection.updatedDate &&
+                      ` · 更新于 ${new Date(collection.updatedDate).toLocaleDateString('zh-CN')}`}
+                  </p>
+                </a>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  // 详情页：按 slug 查找合集
+  const collection = getCollectionBySlug(slug);
+
+  if (!collection) {
+    return (
+      <div className="collection-page">
+        <a href={collectionsHref} className="collection-back">
+          ← 返回合集索引
+        </a>
+        <p className="collection-empty">合集不存在</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="collection-page">
+      <header className="collection-header">
+        <a href={collectionsHref} className="collection-back">
+          ← 返回合集索引
+        </a>
+        <h1 className="collection-title">{collection.title}</h1>
+        {collection.description && (
+          <p className="collection-description">{collection.description}</p>
+        )}
+        <p className="collection-meta">
+          {collection.count} 篇文章 · 创建于{' '}
+          {new Date(collection.createdDate || '').toLocaleDateString('zh-CN')}
+        </p>
+      </header>
+
+      <section className="collection-posts">
+        <ol className="ordered-post-list">
+          {collection.posts.map((post, index) => (
+            <li key={post.route} className="ordered-post-item">
+              <span className="post-order">{index + 1}</span>
+              <div className="post-info">
+                <a href={`${base}${post.route}`} className="post-link">
+                  {post.collectionTitle || post.title}
+                </a>
+                <time className="post-date">
+                  {new Date(post.createDate).toLocaleDateString('zh-CN')}
+                </time>
+                {post.description && <p className="post-desc">{post.description}</p>}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </div>
+  );
+};
+
+export default CollectionPageLayout;

--- a/themes/lucid/src/layouts/Home.tsx
+++ b/themes/lucid/src/layouts/Home.tsx
@@ -1,10 +1,22 @@
 import type { LayoutProps } from '@cogita/shared';
 import { PostList, TagCloud } from '@cogita/ui';
+import { usePageData } from '@rspress/runtime';
 import type React from 'react';
+import { allCollections } from 'virtual-collections-data';
 import { allPosts } from 'virtual-posts-data';
 import { allTags, tagsConfig } from 'virtual-tags-data';
 
+/**
+ * 首页布局组件
+ *
+ * 双栏结构：
+ * - 左侧 aside：标签云（TagCloud）+ 合集列表
+ * - 右侧 main：最新文章（PostList）
+ */
 const HomeLayout: React.FC<LayoutProps> = () => {
+  const pageData = usePageData();
+  const base = (pageData?.siteData?.base || '').replace(/\/$/, '');
+
   return (
     <div className="home-layout">
       <div className="home-content">
@@ -13,9 +25,22 @@ const HomeLayout: React.FC<LayoutProps> = () => {
             <h2 className="sidebar-title">标签</h2>
             <TagCloud tags={allTags} config={tagsConfig.tagCloud} />
           </section>
-          <section className="sidebar-section sidebar-placeholder">
+          <section className="sidebar-section">
             <h2 className="sidebar-title">合集</h2>
-            <p className="sidebar-hint">即将推出</p>
+            {allCollections.length === 0 ? (
+              <p className="sidebar-hint">暂无合集</p>
+            ) : (
+              <ul className="sidebar-collections">
+                {allCollections.slice(0, 5).map((collection) => (
+                  <li key={collection.slug}>
+                    <a href={`${base}${collection.route}`} className="sidebar-collection-link">
+                      {collection.title}
+                      <span className="sidebar-collection-count">{collection.count}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
           </section>
         </aside>
 

--- a/themes/lucid/src/theme.css
+++ b/themes/lucid/src/theme.css
@@ -334,6 +334,286 @@
   color: var(--cogita-text-color-secondary);
 }
 
+/* ============================================
+   合集页面样式
+   ============================================ */
+.collection-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.collection-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--cogita-border-color);
+}
+
+.collection-back {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+  text-decoration: none;
+  margin-bottom: 0.5rem;
+}
+
+.collection-back:hover {
+  color: var(--cogita-primary-color);
+}
+
+.collection-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--cogita-title-color);
+  margin: 0 0 0.5rem 0;
+}
+
+.collection-description {
+  color: var(--cogita-text-color-secondary);
+  font-size: 1.125rem;
+  margin: 0 0 0.5rem 0;
+  line-height: 1.6;
+}
+
+.collection-meta {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+  margin: 0;
+}
+
+/* 合集卡片（索引页） */
+.collection-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.collection-card {
+  display: block;
+  padding: 1.5rem;
+  background: var(--cogita-bg-soft);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.collection-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.collection-card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--cogita-title-color);
+  margin: 0 0 0.5rem 0;
+}
+
+.collection-card-desc {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+  margin: 0 0 0.75rem 0;
+  line-height: 1.5;
+}
+
+.collection-card-meta {
+  font-size: 0.75rem;
+  color: var(--cogita-text-color-secondary);
+  margin: 0;
+}
+
+/* 有序文章列表（详情页） */
+.ordered-post-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ordered-post-item {
+  display: flex;
+  gap: 1rem;
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--cogita-border-color);
+}
+
+.ordered-post-item:last-child {
+  border-bottom: none;
+}
+
+.post-order {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--cogita-bg-soft);
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--cogita-text-color-secondary);
+}
+
+.post-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.post-link {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--cogita-title-color);
+  text-decoration: none;
+}
+
+.post-link:hover {
+  color: var(--cogita-primary-color);
+}
+
+.post-date {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--cogita-text-color-secondary);
+  margin-top: 0.25rem;
+}
+
+.post-desc {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+  margin: 0.5rem 0 0 0;
+  line-height: 1.5;
+}
+
+/* 上一篇/下一篇导航 */
+.collection-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--cogita-border-color);
+}
+
+.collection-nav a {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color);
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  background: var(--cogita-bg-soft);
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.collection-nav a:hover {
+  background: var(--cogita-border-color);
+}
+
+.collection-empty {
+  color: var(--cogita-text-color-secondary);
+  font-size: 1rem;
+  padding: 2rem 0;
+}
+
+/* ============================================
+   文章页合集导航样式
+   ============================================ */
+.article-collection-nav {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background: var(--cogita-bg-soft);
+  border-radius: 8px;
+}
+
+.collection-nav-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.collection-nav-link {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--cogita-title-color);
+  text-decoration: none;
+}
+
+.collection-nav-link:hover {
+  color: var(--cogita-primary-color);
+}
+
+.collection-nav-progress {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+}
+
+.collection-nav-buttons {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.collection-nav-btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  background: white;
+  border: 1px solid var(--cogita-border-color);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.collection-nav-btn:hover {
+  border-color: var(--cogita-primary-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.collection-nav-btn-placeholder {
+  background: transparent;
+  border: 1px dashed var(--cogita-border-color);
+}
+
+.collection-nav-btn-label {
+  font-size: 0.75rem;
+  color: var(--cogita-text-color-secondary);
+}
+
+.collection-nav-btn-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--cogita-title-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collection-nav-breadcrumb {
+  font-size: 0.875rem;
+  color: var(--cogita-text-color-secondary);
+}
+
+.collection-nav-breadcrumb a {
+  color: var(--cogita-text-color);
+  text-decoration: none;
+}
+
+.collection-nav-breadcrumb a:hover {
+  color: var(--cogita-primary-color);
+}
+
+.collection-nav-breadcrumb .separator {
+  margin: 0 0.5rem;
+}
+
+/* 打破 .rspress-doc 宽度限制（合集页同首页/标签页） */
+.rspress-doc:has(.collection-page) {
+  max-width: none !important;
+  margin: 0 !important;
+}
+
 /* 响应式设计 */
 @media (max-width: 768px) {
   .content-layout {
@@ -365,6 +645,11 @@
   .tag-sidebar {
     position: static;
     order: 2;
+  }
+
+  .collection-nav-buttons {
+    flex-direction: column;
+    gap: 0.75rem;
   }
 
   .header-content {
@@ -418,6 +703,19 @@ aside.rspress-sidebar {
   .related-tags,
   .tag-info {
     background: #161b22;
+  }
+
+  .article-collection-nav {
+    background: #161b22;
+  }
+
+  .collection-nav-btn {
+    background: #0d1117;
+    border-color: var(--cogita-border-color);
+  }
+
+  .collection-nav-btn-placeholder {
+    background: transparent;
   }
 }
 

--- a/themes/lucid/src/types.d.ts
+++ b/themes/lucid/src/types.d.ts
@@ -62,3 +62,51 @@ declare module 'virtual-tags-data' {
   export function getPostsByTag(tagName: string): PostReference[];
   export function getRelatedTags(currentTag: string, limit?: number): TagData[];
 }
+
+declare module 'virtual-collections-data' {
+  interface CollectionPost {
+    title: string;
+    route: string;
+    createDate: string;
+    updateDate: string;
+    description?: string;
+    order: number;
+    collectionTitle?: string;
+  }
+
+  interface CollectionData {
+    slug: string;
+    title: string;
+    description?: string;
+    cover?: string;
+    posts: CollectionPost[];
+    count: number;
+    route: string;
+    createdDate?: string;
+    updatedDate?: string;
+  }
+
+  interface CollectionsConfig {
+    enabled: boolean;
+    routePrefix: string;
+    metadata: Record<string, { title?: string; description?: string; cover?: string }>;
+    excludeCollections: string[];
+    minPostCount: number;
+  }
+
+  interface CollectionStats {
+    totalCollections: number;
+    largest: CollectionData;
+    newest: CollectionData;
+    averagePostsPerCollection: number;
+  }
+
+  export const allCollections: CollectionData[];
+  export const collectionMap: Record<string, CollectionData>;
+  export const collectionsConfig: CollectionsConfig;
+  export const collectionStats: CollectionStats;
+
+  export function getCollectionBySlug(slug: string): CollectionData | undefined;
+  export function getPostsByCollection(slug: string): CollectionPost[];
+  export function getCollectionByPostRoute(route: string): CollectionData | undefined;
+}


### PR DESCRIPTION
合集插件（@cogita/plugin-collections）实现完整功能：
- 有序系列文章管理（frontmatter collection + order 字段）
- 自动生成合集索引页和详情页路由
- 虚拟模块 virtual-collections-data 暴露合集数据和辅助函数
- 合集元数据覆盖（config.metadata 按 slug 索引）
- 最小文章数阈值过滤（minPostCount）

主题 lucid 集成：
- 新增 Collection.tsx 布局（索引页卡片 + 详情页有序列表双模式）
- 新增 CollectionNav.tsx 全局组件（文章页合集归属 + 上下篇导航）
- 首页侧边栏展示合集列表
- 完整 CSS 样式含响应式和暗色模式支持

核心框架修复：
- 修复 createThemePlugin 未传递 globalUIComponents 的 bug
- 修复 globalStyles 路径截断 bug（?.[0] 取字符串首字符改为直接传递）
- 新增 CLI preview 命令实现（之前为 TODO）

文档更新：
- 更新设计文档实现进度（Phase 1-2 完成，Phase 3 部分完成）
- 更新插件列表，collections 从'设计中'改为'已完成'
- 创建 changeset 版本变更记录