### PR TITLE
feat(images): add image plugin and media experience

### DIFF
--- a/.changeset/add-images-plugin.md
+++ b/.changeset/add-images-plugin.md
@@ -1,0 +1,10 @@
+---
+'@cogita/plugin-images': minor
+'@cogita/core': patch
+'@cogita/shared': patch
+'@cogita/plugin-posts-frontmatter': patch
+'@cogita/ui': minor
+'@cogita/theme-lucid': patch
+---
+
+新增图片插件，支持公共图片扫描、文章封面元数据、图片尺寸读取、封面缺失校验、使用统计和运行时虚拟模块，并在 Lucid 主题首页展示文章封面；同时透传 Rspress 原生图片放大配置并补充正文图片样式。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,8 @@ Cogita 生态系统
 │   │   ├── @cogita/plugin-blog-list
 │   │   ├── @cogita/plugin-tags
 │   │   ├── @cogita/plugin-categories
-│   │   └── @cogita/plugin-archives
+│   │   ├── @cogita/plugin-archives
+│   │   └── @cogita/plugin-images
 │   ├── SEO 与发现
 │   │   ├── @cogita/plugin-rss                ✅
 │   │   ├── @cogita/plugin-sitemap
@@ -168,6 +169,18 @@ interface CogitaTheme {
   - [ ] 面包屑导航
   - [ ] 基于分类的路由
   - [ ] 嵌套分类支持
+
+- [x] `@cogita/plugin-images` 🚧 二期开发中
+  - [x] 图片资源目录约定
+  - [x] 文章封面和图片元数据
+  - [x] 本地图片路径校验
+  - [x] `virtual-images-data` 虚拟模块
+  - [x] Lucid 主题封面展示
+  - [x] 封面缺少 alt 的非阻断警告
+  - [x] 图片封面使用统计与未使用图片查询
+  - [x] 正文图片基础样式与 Rspress medium-zoom 透传
+  - [ ] 正文图片 figure 与说明文字自动化
+  - [ ] 独立图片优化插件
 
 #### SEO 与发现插件
 

--- a/blog/cogita.config.ts
+++ b/blog/cogita.config.ts
@@ -15,6 +15,23 @@ export default defineConfig({
     extensions: ['md', 'mdx'],
   },
 
+  images: {
+    enabled: true,
+    dir: 'public/images',
+    readDimensions: true,
+    warnOnMissingAlt: true,
+  },
+
+  markdown: {
+    image: {
+      checkDeadImages: true,
+    },
+  },
+
+  mediumZoom: {
+    selector: '.rspress-doc p > img, .rspress-doc figure:not([class*="postCover"]) > img',
+  },
+
   rss: {
     title: 'Cogita Blog RSS',
     description: '记录编码、创造与思考的瞬间',

--- a/blog/posts/introducing-cogita.md
+++ b/blog/posts/introducing-cogita.md
@@ -10,6 +10,9 @@ tags:
   - 开源
 author: "wu9o"
 excerpt: "在 Rspress 的强大功能之上，Cogita 旨在提供一种极致简单、无需配置的博客写作体验。本文将深入探讨 Cogita 的诞生背景、核心架构、使用方法以及未来规划。"
+image: /images/cogita-architecture.svg
+imageAlt: Cogita 主题驱动架构示意图
+imageCaption: Cogita 通过主题声明插件依赖，并将构建数据交给运行时组件。
 ---
 
 ## 背景：为什么需要 Cogita？
@@ -26,6 +29,8 @@ Rspress 是一个性能卓越、功能强大的静态站点生成器 (SSG)。它
 **Cogita** 的诞生就是为了解决这个问题。它的核心目标是：**成为一个基于 Rspress、无需繁琐配置、真正开箱即用的静态博客框架。** 你只需要安装它，选择一个喜欢的主题，然后就可以立即开始写作。
 
 ## 架构设计：Cogita 的内在机制
+
+![Cogita 主题驱动架构示意图](/images/cogita-architecture.svg)
 
 Cogita 的设计哲学是“约定优于配置”，它通过一套精心设计的架构，将博客系统的复杂性封装起来，为用户提供最简洁的接口。
 

--- a/blog/public/images/cogita-architecture.svg
+++ b/blog/public/images/cogita-architecture.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Cogita 主题驱动架构</title>
+  <desc id="desc">配置、主题插件、虚拟模块和运行时组件组成的流程图</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f5f7ff" />
+      <stop offset="1" stop-color="#e8f4f1" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#1e293b" flood-opacity="0.12" />
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0 0L10 5L0 10Z" fill="#526581" />
+    </marker>
+  </defs>
+  <rect width="1200" height="675" rx="32" fill="url(#bg)" />
+  <text x="72" y="88" fill="#172033" font-family="system-ui, sans-serif" font-size="42" font-weight="700">Cogita</text>
+  <text x="72" y="128" fill="#526581" font-family="system-ui, sans-serif" font-size="22">主题驱动的静态博客架构</text>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="215" width="216" height="150" rx="20" fill="#ffffff" />
+    <rect x="348" y="185" width="250" height="210" rx="20" fill="#ffffff" />
+    <rect x="658" y="215" width="216" height="150" rx="20" fill="#ffffff" />
+    <rect x="934" y="185" width="194" height="210" rx="20" fill="#ffffff" />
+  </g>
+
+  <g fill="#172033" font-family="system-ui, sans-serif" text-anchor="middle">
+    <text x="180" y="267" font-size="24" font-weight="700">配置</text>
+    <text x="180" y="306" fill="#526581" font-size="17">站点 · 主题 · 插件</text>
+    <text x="473" y="238" font-size="24" font-weight="700">主题与插件</text>
+    <text x="473" y="280" fill="#526581" font-size="17">扫描内容 · 校验配置</text>
+    <text x="473" y="311" fill="#526581" font-size="17">生成页面 · 暴露数据</text>
+    <text x="766" y="267" font-size="24" font-weight="700">虚拟模块</text>
+    <text x="766" y="306" fill="#526581" font-size="17">构建时 → 运行时</text>
+    <text x="1031" y="238" font-size="24" font-weight="700">博客页面</text>
+    <text x="1031" y="280" fill="#526581" font-size="17">文章列表</text>
+    <text x="1031" y="311" fill="#526581" font-size="17">封面与内容</text>
+  </g>
+
+  <g stroke="#526581" stroke-width="4" fill="none" marker-end="url(#arrow)">
+    <path d="M288 290H338" />
+    <path d="M598 290H648" />
+    <path d="M874 290H924" />
+  </g>
+
+  <rect x="72" y="490" width="1056" height="74" rx="18" fill="#172033" opacity="0.95" />
+  <text x="600" y="536" fill="#ffffff" font-family="system-ui, sans-serif" font-size="21" text-anchor="middle">约定优于配置 · 渐进式增强 · 开箱即用</text>
+</svg>

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -9,6 +9,7 @@
 - **[插件开发指南](./plugin-development.md)** - 从零开发Cogita插件的完整教程
 - **[Posts Frontmatter插件设计](./plugin-posts-frontmatter-design.md)** - 核心数据插件的架构设计
 - **[RSS插件设计](./plugin-rss-design.md)** - RSS订阅插件的架构设计和实现方案
+- **[图片插件设计](./plugin-images-design.md)** - 图片资源、封面和元数据插件的实现方案
 
 ### 📝 计划中文档
 
@@ -43,6 +44,7 @@
 | `@cogita/plugin-rss` | RSS/Atom/JSON Feed 生成 | ✅ 完成 | [设计文档](./plugin-rss-design.md) |
 | `@cogita/plugin-tags` | 标签管理与标签云 | ✅ 完成 | [README](../../plugins/tags/README.md) |
 | `@cogita/plugin-collections` | 合集（系列文章）管理 | ✅ 完成 | [设计文档](./plugin-collections-design.md) |
+| `@cogita/plugin-images` | 公共图片、文章封面和图片元数据 | 🚧 二期开发中 | [设计文档](./plugin-images-design.md) |
 
 ### 📝 计划中插件
 

--- a/docs/plugins/plugin-images-design.md
+++ b/docs/plugins/plugin-images-design.md
@@ -1,0 +1,561 @@
+# 图片插件架构设计与实现规划
+
+**文档版本**: 1.1
+**创建日期**: 2026年8月21日
+**插件名称**: `@cogita/plugin-images`
+**状态**: 🚧 第一阶段已完成，第二阶段 A 开发中
+**依赖**: `@cogita/plugin-posts-frontmatter`、`@cogita/ui`（主题集成阶段）
+
+## 一、背景与目标
+
+当前 Cogita 的示例博客以文字和代码块为主，文章可以引用图片，但仓库没有统一的图片资源约定、图片元数据模型或主题展示能力。现有最佳实践文档虽然给出了 Markdown 图片语法示例，却没有提供以下能力：
+
+- 统一管理站点图片和文章局部图片；
+- 从文章 frontmatter 读取封面图并传递给主题；
+- 检查图片路径是否存在，减少部署后出现失效图片；
+- 为主题提供尺寸、替代文本、说明文字等图片元数据；
+- 在站点使用 `base` 或 `assetPrefix` 时正确生成图片 URL；
+- 在不配置图片功能时不破坏现有的零配置体验。
+
+本插件第一阶段的目标是建立“图片资源与元数据层”，让主题和文章可以稳定地使用图片。图片压缩、格式转换和响应式图片属于后续性能优化，不在第一阶段强行加入。
+
+## 二、插件定位
+
+插件命名为 `@cogita/plugin-images`，而不是直接命名为 `@cogita/plugin-image-optimization`。
+
+两者解决的问题不同：
+
+| 插件 | 主要职责 | 规划阶段 |
+| --- | --- | --- |
+| `@cogita/plugin-images` | 图片资源发现、路径解析、元数据、封面和主题展示 | 当前优先实现 |
+| `@cogita/plugin-image-optimization` | 压缩、WebP/AVIF、响应式尺寸、缓存和性能策略 | 后续阶段 |
+
+这样可以先解决“文章有图片且能正确显示”的基础问题，同时不把原生图片处理库、构建耗时和部署复杂度带入第一个版本。
+
+## 三、设计原则
+
+1. **尊重 Rspress 的资源处理能力**：第一阶段不重写 Markdown 图片语法。当前项目使用的 Rspress 构建链不会把 `public` 目录自动复制到静态输出，因此插件只在生产构建的 `afterBuild` 阶段复制已扫描的公共图片目录；正文局部图片仍由 Rspress 处理。
+2. **插件负责数据，主题负责展示**：插件扫描和验证图片，主题和 UI 组件决定封面、图片卡片和图片说明的视觉形式。
+3. **资源边界清晰**：正文相对图片交给 Rspress 资源管线，主题封面和运行时图片统一使用 `public/images` 或外部 URL。
+4. **配置可选，基础行为稳定**：没有 `images` 配置时，插件应产生空数据而不是让主题导入虚拟模块失败。
+5. **可访问性优先**：图片应支持 `alt`；缺失时可以使用 frontmatter 标题或文件名作为降级值，并在严格模式下给出警告或错误。
+6. **URL 与文件路径分离**：内部使用绝对文件路径解析资源，暴露给浏览器时统一生成带 `base` 的 URL。
+
+## 四、第一阶段范围
+
+### 4.1 支持的图片来源
+
+第一阶段只把 `public/images` 作为主题封面和运行时图片数据的来源：
+
+```text
+blog/
+├── public/
+│   └── images/              # 站点公共图片，URL 形如 /images/xxx.png
+└── posts/
+    └── article-slug/
+        ├── index.md         # 文章
+        └── assets/           # 正文局部图片，由 Rspress 原生处理
+```
+
+正文中的相对图片，例如 `./assets/diagram.png`，直接交给 Rspress 的 Markdown/MDX 资源管线处理。对于主题首页、文章列表这类运行时 React 组件使用的封面，第一阶段统一放入 `public/images`，避免插件自行猜测 Rspress 对局部资源生成的最终 URL。
+
+这是一个有意的边界：Rspress 会把 Markdown 中的相对图片转换为资源导入；当前构建链不会自动复制 `public` 图片，因此插件在生产构建的 `afterBuild` 阶段补齐已扫描的公共图片目录。插件在 `beforeBuild` 阶段无法可靠知道局部资源最终是否会被哈希、改名或放入 `static` 目录。相关行为以 [Rspress 静态资源文档](https://www.rspress.dev/guide/basic/static-assets) 为准。
+
+默认支持的扩展名：`.png`、`.jpg`、`.jpeg`、`.gif`、`.webp`、`.avif`、`.svg`。
+
+### 4.2 Frontmatter 图片字段
+
+第一阶段支持一个文章封面字段。封面推荐使用 `public` 逻辑路径或外部 URL：
+
+```yaml
+---
+title: "文章标题"
+image: "/images/cover.png"
+imageAlt: "文章封面描述"
+imageCaption: "文章封面说明"
+---
+```
+
+字段约定：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `image` | `string` | 封面图片路径，第一阶段支持 `public` 逻辑路径或外部 URL |
+| `imageAlt` | `string` | 封面替代文本 |
+| `imageCaption` | `string` | 封面说明文字 |
+
+正文插图仍然使用标准 Markdown，局部图片不需要通过 `image` 字段声明：
+
+```markdown
+![系统架构图](./assets/architecture.png)
+```
+
+第一阶段不要求插件接管正文 Markdown 图片。Rspress 已提供 `markdown.image.checkDeadImages`，可以负责相对路径和 `public` 路径的死图检查；图片插件只负责 frontmatter 封面解析、公共图片元数据和主题数据。
+
+### 4.3 图片元数据
+
+构建阶段的数据和浏览器运行时的数据必须分离。绝对文件路径只能留在构建进程内，不能写入虚拟模块，否则会把开发机目录泄露到生成的 JavaScript 中。
+
+构建阶段使用内部类型：
+
+```typescript
+interface ResolvedImage {
+  filePath: string;
+  relativePath: string;
+  logicalSrc: string;
+  name: string;
+  extension: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+  caption?: string;
+  postRoute?: string;
+}
+```
+
+向主题暴露的运行时数据使用不包含本地路径的类型：
+
+```typescript
+export interface ImageData {
+  /** 站点逻辑路径或外部 URL，不包含本机绝对路径 */
+  src: string;
+  /** 图片相对于项目根目录的路径；外部 URL 没有此字段 */
+  relativePath?: string;
+  /** 原始文件名；外部 URL 可能没有此字段 */
+  name?: string;
+  /** 文件扩展名；外部 URL 可能没有此字段 */
+  extension?: string;
+  /** 图片宽度，无法读取时为空 */
+  width?: number;
+  /** 图片高度，无法读取时为空 */
+  height?: number;
+  /** 替代文本 */
+  alt?: string;
+  /** 图片说明 */
+  caption?: string;
+  /** 图片来源 */
+  source: 'public' | 'external';
+  /** 所属文章路由，公共图片为空 */
+  postRoute?: string;
+}
+```
+
+这里的 `src` 应保存站点逻辑路径，例如 `/images/cover.png`，而不是在构建阶段直接拼接 `site.base`。`allImages` 主要包含扫描到的公共图片，外部封面只出现在对应文章的 `postCovers` 中。主题组件在浏览器运行时通过 `@rspress/runtime` 的 `normalizeImagePath` 处理 `base`。`builderConfig.output.assetPrefix` 属于构建产物和 CDN 资源策略，不能简单当作站点 `base` 拼接到所有图片路径上。
+
+插件通过 `virtual-images-data` 暴露：
+
+```typescript
+declare module 'virtual-images-data' {
+  interface ImageUsage {
+    src: string;
+    count: number;
+    postRoutes: string[];
+  }
+
+  export const allImages: ImageData[];
+  export const postCovers: Record<string, ImageData>;
+  export const imageUsage: Record<string, ImageUsage>;
+  export function getUnusedImages(): ImageData[];
+
+  export function getImageBySrc(src: string): ImageData | undefined;
+  export function getPostCover(route: string): ImageData | undefined;
+}
+```
+
+虚拟模块只包含不含本地绝对路径的 `ImageData` 和 `ImageUsage`，不得包含 `ResolvedImage.filePath`、文章源文件绝对路径或其他仅构建期使用的信息。
+
+## 五、配置设计
+
+在 `@cogita/core` 中增加结构化配置：
+
+```typescript
+export interface ImagesConfig {
+  /** 是否启用图片扫描和校验，默认 true */
+  enabled?: boolean;
+  /** 公共图片目录，相对于项目根目录，默认 public/images */
+  dir?: string;
+  /** 支持的图片扩展名 */
+  extensions?: string[];
+  /** 是否读取图片尺寸，默认 true */
+  readDimensions?: boolean;
+  /** 找不到图片时是否让构建失败，默认跟随 strict */
+  failOnMissing?: boolean;
+  /** 是否警告文章封面缺少明确的替代文本，默认 false */
+  warnOnMissingAlt?: boolean;
+}
+```
+
+示例配置：
+
+```typescript
+export default defineConfig({
+  images: {
+    enabled: true,
+    dir: 'public/images',
+    extensions: ['png', 'jpg', 'jpeg', 'webp', 'avif', 'svg'],
+    readDimensions: true,
+  },
+});
+```
+
+配置默认值应在 core 的增强配置中统一补齐，并通过 `CogitaPluginConfig.images` 传给插件工厂。插件不应重复读取用户配置文件。
+
+## 六、路径解析规则
+
+图片路径解析必须区分三种形式：
+
+| 写法 | 解析方式 |
+| --- | --- |
+| Markdown 中的 `./assets/diagram.png` | 交给 Rspress 解析为构建资源导入 |
+| frontmatter 中的 `/images/logo.png` | 从 `public/images` 解析，并只保存逻辑路径 |
+| `https://example.com/a.png` | 视为外部 URL，不扫描、不复制、不校验本地文件 |
+
+解析结果在构建期内部可以同时保留 `filePath` 和 `src`，但虚拟模块只能输出 `src` 和展示元数据。`filePath` 只供构建期检查和读取尺寸。
+
+当站点配置为 `base: '/cogita/'` 时，运行时组件应通过 `normalizeImagePath('/images/logo.png')` 得到：
+
+```text
+/cogita/images/logo.png
+```
+
+`normalizeImagePath` 应从当前项目已有依赖 `@rspress/runtime` 引入；不能在插件构建阶段手动拼接 `base`。当 `src` 已经是完整的 `http://` 或 `https://` URL 时，不得再次拼接 `base`。Rspress 的 `base` 和 `builderConfig.output.assetPrefix` 是不同层次的配置，后者只用于构建静态资源的 CDN 前缀，不能作为图片逻辑路径的替代品。
+
+## 七、插件生命周期与数据流
+
+```mermaid
+flowchart LR
+    A[文章 frontmatter] --> B[图片路径解析]
+    C[public/images] --> D[图片扫描]
+    B --> E[图片存在性校验]
+    D --> E
+    E --> F[读取尺寸与元数据]
+    F --> G[virtual-images-data]
+    G --> H[Lucid 主题]
+    G --> I[其他主题与插件]
+    H --> J[封面卡片与图片说明]
+```
+
+建议的插件实现：
+
+```typescript
+export function pluginImages(config: CogitaPluginConfig): RspressPlugin {
+  let allImages: ImageData[] = [];
+  let postCovers: Record<string, ImageData> = {};
+
+  return {
+    name: '@cogita/plugin-images',
+
+    async beforeBuild() {
+      // 扫描公共图片、解析封面、读取尺寸并执行路径校验
+    },
+
+    addRuntimeModules() {
+      // 暴露稳定的虚拟模块，即使没有任何图片也要提供空数组和空映射
+      return {
+        'virtual-images-data': '...',
+      };
+    },
+  };
+}
+```
+
+插件不需要 `addPages`，因为图片不是独立页面。当前项目使用的 Rspress 构建链不会把 `public` 目录自动复制到静态输出，因此插件只在生产构建的 `afterBuild` 阶段复制已扫描的公共图片目录；这不涉及正文局部图片的二次处理。正文局部图片的死图检查应通过 core 透传 Rspress 的 `markdown.image.checkDeadImages` 完成，而不是重复实现一套 Markdown AST 扫描器。
+
+## 八、与现有插件和主题的集成
+
+### 8.1 与 posts-frontmatter 集成
+
+图片插件依赖 `@cogita/plugin-posts-frontmatter` 的文章路由和 frontmatter 约定，但不应重复实现完整的文章页面生成逻辑。
+
+当前 Rspress 插件生命周期的 `beforeBuild` 钩子是并行执行的，图片插件不能等待 `pluginPostsFrontmatter` 的内部 `allPostsData` 状态，也不能在 Node 构建阶段直接依赖 `virtual-posts-data`。实现时需要评估两种方案：
+
+1. 扩展 `PostFrontmatter`，直接增加 `image`、`imageAlt`、`imageCaption` 字段；
+2. 图片插件独立读取文章 frontmatter，并通过文章路由与 `virtual-posts-data` 关联。
+
+短期优先方案是：扩展 `PostFrontmatter`，直接增加可选的图片字段，同时让图片插件复用 `getFrontmatterFromFile` 和统一的路由计算逻辑。图片插件仍然独立扫描文章，不读取另一个插件的运行时虚拟模块。这样虽然暂时存在一次额外扫描，但符合当前并行插件模型，行为也容易验证。第一阶段只接受能映射为 `public` 逻辑路径或外部 URL 的封面。
+
+长期更好的方案是由 core 提供构建期 `ContentIndex`：posts 插件负责建立一次文章索引，tags、collections、rss、images 通过构建上下文读取同一份索引。这个改造不应在图片插件中偷偷实现，避免再增加一个隐式的全局状态系统。
+
+### 8.2 与 Lucid 主题集成
+
+Lucid 主题需要：
+
+- 在主题插件列表中声明 `pluginImages`；
+- 在首页文章列表中支持可选封面图；
+- 为封面图提供稳定的宽高和 `alt`；
+- 只在文章存在封面时渲染封面区域，避免无图文章出现空白占位；
+- 使用当前依赖 `@rspress/runtime` 的 `normalizeImagePath` 正确处理站点 `base`；
+- 保证图片插件无配置时 `virtual-images-data` 仍可导入。
+
+现有 `PostList` 需要增加可选能力，例如：
+
+```typescript
+export interface PostListProps {
+  posts: Post[];
+  showCover?: boolean;
+  coverPosition?: 'top' | 'left';
+}
+```
+
+默认主题第一阶段可以只展示首页文章卡片顶部的封面，不修改正文 Markdown 图片的渲染方式。
+
+### 8.3 与 @cogita/ui 集成
+
+第一阶段建议新增一个轻量的 `PostCover` 或 `ImageFigure` 组件，而不是建立完整图片组件体系：
+
+- 支持 `src`、`alt`、`width`、`height`、`caption`；
+- 使用原生 `<img>`，避免引入额外客户端运行时；
+- 默认 `loading="lazy"`，封面可由主题决定是否使用 `eager`；
+- 保持 CSS Modules 样式隔离；
+- 后续图片优化插件可以在此组件上增加 `srcset` 和 `<picture>`。
+
+### 8.4 现有插件架构审计与前置调整
+
+图片插件可以按现有工厂模式实现，但当前架构有几处需要明确约束，否则后续插件数量增加后会出现隐式依赖和零配置失效。
+
+| 优先级 | 当前问题 | 对图片插件的影响 | 当前方案 |
+| --- | --- | --- | --- |
+| P0 | Rspress 生命周期钩子并行执行 | 不能依赖 posts 插件先完成扫描 | 图片插件独立读取文章，复用纯工具函数 |
+| P0 | 可选插件可能返回 `null`，主题却无条件导入虚拟模块 | 无 `images` 配置时可能出现模块解析失败 | 图片插件始终返回插件实例，并始终注册空数据虚拟模块 |
+| P0 | 构建路径、站点 `base`、资源 `assetPrefix` 没有分层 | 图片 URL 可能在本地正常、部署后错误 | 虚拟模块只暴露逻辑路径，运行时使用 `normalizeImagePath` |
+| P0 | Rspress 已经负责 Markdown 图片导入和死图检查 | 插件重复解析 Markdown 会与 Rspress 资源管线冲突 | 正文图片交给 Rspress，插件只处理 frontmatter 和公共图片 |
+| P0 | 当前 posts 插件页面 frontmatter 字符串存在旧格式残留 | 图片集成测试可能被无关路由问题干扰 | 开始图片实现前先修复并验证文章页面生成 |
+| P1 | tags、collections、rss、images 都重复扫描文章 | 构建耗时和解析结果可能逐渐不一致 | 图片一期保持独立扫描；后续引入 core `ContentIndex` |
+| P1 | `CogitaPluginConfig` 与 core 配置类型重复，工厂处有 `any` | 图片配置容易出现多处定义不一致 | 图片一期统一新增类型来源，后续收敛为 normalized config/context |
+| P1 | 用户配置没有通用 `plugins` 扩展点 | 自定义主题之外难以注册额外插件 | 图片一期由 Lucid 主题自动声明；通用用户插件注册另立议题 |
+
+### 8.5 建议的插件契约演进
+
+现阶段不建议为了图片插件立刻重写整个插件系统，但应把后续架构演进方向固定下来：
+
+```typescript
+export interface CogitaBuildContext {
+  root: string;
+  cwd: string;
+  config: CogitaFullConfig;
+  content?: {
+    posts: ReadonlyArray<PostFrontmatter>;
+  };
+  logger: CogitaLogger;
+}
+```
+
+未来可以将插件工厂从“只接收一个可扩展配置对象”演进为“接收规范化配置和构建上下文”，但仍保留现有 `CogitaPluginFactory` 的兼容适配层。演进顺序建议是：
+
+1. 先统一 `CogitaFullConfig` 和 `CogitaPluginConfig` 的类型来源；
+2. 增加只读的构建上下文和 logger，不允许插件直接共享可变状态；
+3. 增加插件依赖声明和拓扑排序，仅用于确实需要顺序的生命周期；
+4. 由 core 创建统一内容索引，逐步消除重复扫描；
+5. 最后再考虑 `CogitaConfig.plugins`，解决用户直接注册插件的问题。
+
+图片插件一期不应依赖尚未存在的 `CogitaBuildContext`，否则设计会超前于当前运行时；但其工具函数、错误模型和数据结构应按这个方向保持可迁移。
+
+### 8.6 一期具体实现接口
+
+一期先把实现限制在纯函数和一个薄的 Rspress 适配层中，避免把文件系统、frontmatter、URL 处理和虚拟模块字符串拼接全部塞进 `plugin.ts`。
+
+建议的内部接口：
+
+```typescript
+interface NormalizedImagesConfig {
+  enabled: boolean;
+  dir: string;
+  extensions: string[];
+  readDimensions: boolean;
+  failOnMissing: boolean;
+}
+
+interface ImageReference {
+  value: string;
+  postFilePath?: string;
+  postRoute?: string;
+  alt?: string;
+  caption?: string;
+}
+
+function normalizeImagesConfig(config: CogitaPluginConfig): NormalizedImagesConfig;
+
+function scanPublicImages(
+  root: string,
+  config: NormalizedImagesConfig
+): Promise<ResolvedImage[]>;
+
+function resolveCoverReference(
+  reference: ImageReference,
+  root: string,
+  config: NormalizedImagesConfig
+): Promise<ResolvedImage | null>;
+
+function toRuntimeImage(image: ResolvedImage): ImageData;
+
+function createImagesRuntimeModule(
+  images: ImageData[],
+  postCovers: Record<string, ImageData>
+): string;
+```
+
+`plugin.ts` 的职责只保留为：创建插件状态、调用这些函数、记录错误、在 `addRuntimeModules` 中输出已经冻结的数据快照。建议的构建顺序如下：
+
+1. 规范化图片配置和项目根目录；
+2. 扫描 `public/images`，以逻辑 URL 去重；
+3. 读取文章 frontmatter 中的封面字段；
+4. 对 `/images/...` 封面在公共图片索引中查找，对外部 URL 直接保留；
+5. 根据 `readDimensions` 读取尺寸，并补齐 alt 降级值；
+6. 汇总缺失图片和无效配置，按 `strict`/`failOnMissing` 决定警告或抛错；
+7. 将构建期对象转换为不含绝对路径的 `ImageData`；
+8. 由 `addRuntimeModules` 输出 JSON 数据和查询函数。
+
+虚拟模块生成函数必须对标题、alt、caption 和 URL 使用 `JSON.stringify`，不能通过手写引号拼接字符串。这样可以避免图片文件名或中文说明文字中的引号、换行破坏生成的 JavaScript。
+
+### 8.7 Rspress 配置透传
+
+图片插件不应自己实现正文死图检查，但 Cogita core 需要保留 Rspress 的配置透传能力。建议在图片实现的前置检查中确认以下配置仍能传递：
+
+```typescript
+builderConfig: {
+  // 站点构建资源的 CDN 前缀，不作为图片逻辑路径使用
+  output: {
+    assetPrefix: '/cogita/',
+  },
+},
+markdown: {
+  image: {
+    checkDeadImages: true,
+  },
+},
+```
+
+当前 `CogitaConfig` 只显式透传 `themeConfig` 和 `builderConfig`，后续如要配置 `markdown.image.checkDeadImages`，应增加与 Rspress 对齐的类型安全 `markdown` 字段，而不是让图片插件直接修改 Rspress 配置对象。
+
+更贴合当前配置命名方式的最小改动是直接增加：
+
+```typescript
+export interface CogitaConfig {
+  markdown?: UserConfig['markdown'];
+}
+```
+
+并在 `createRspressConfig` 中透传 `markdown: cogitaConfig.markdown`。这样图片插件不需要拥有或修改全局 Rspress 配置，其他未来需要 Markdown 能力的插件也可以复用同一个入口。
+
+## 九、实现拆分
+
+### Phase 1：基础图片能力
+
+- [x] 创建 `plugins/images` 包和标准构建配置；
+- [x] 增加 `ImagesConfig`、`ImageData`、插件配置类型；
+- [x] 扫描公共图片目录，并解析文章封面引用；
+- [x] 解析 `image`、`imageAlt`、`imageCaption`；
+- [x] 校验 `public` 封面图片路径并提供 strict/non-strict 行为；
+- [x] 读取常见格式的图片尺寸；
+- [x] 构建期数据与运行时数据分离，禁止暴露绝对文件路径；
+- [x] 生成 `virtual-images-data` 和客户端类型声明；
+- [x] 将图片封面字段接入 `PostFrontmatter` 和 `@cogita/ui` 的 `Post` 类型；
+- [x] Lucid 首页文章卡片展示可选封面；
+- [x] 透传并验证 Rspress 的 `markdown.image.checkDeadImages`；
+- [x] 为示例博客增加一张 `public/images` 图片和一篇带封面的文章；
+- [x] 编写插件 README 和使用示例。
+
+### Phase 2：正文图片体验
+
+#### Phase 2A：可访问性与使用统计
+
+- [x] 增加封面缺少 alt 的非阻断警告；
+- [x] 生成封面图片使用关系 `imageUsage`；
+- [x] 提供 `getUnusedImages()`，支持发现未被文章封面引用的公共图片。
+
+#### Phase 2B：正文图片交互
+
+- [x] 通过 core 透传 Rspress 原生 `mediumZoom`，避免重复引入 Lightbox 依赖；
+- [x] 为正文单图和显式 `figure.cogita-image-figure` 提供统一视觉样式；
+- [ ] 从 Markdown 图片标题自动生成统一的 figure 说明文字；
+- [ ] 评估文章局部图片作为 React 封面的资源清单方案，不直接猜测 Rspress 构建后的文件名；
+
+### Phase 3：图片优化
+
+单独评估 `@cogita/plugin-image-optimization`，包括：
+
+- [ ] JPEG/PNG/WebP/AVIF 压缩；
+- [ ] 多尺寸变体和 `srcset`；
+- [ ] `<picture>` 格式回退；
+- [ ] 构建缓存和增量处理；
+- [ ] 原图保留策略；
+- [ ] 大图片告警和性能预算。
+
+## 十、错误处理与兼容性
+
+| 场景 | 默认行为 | `strict: true` |
+| --- | --- | --- |
+| 没有 `images` 配置 | 提供空虚拟模块 | 不报错 |
+| 图片目录不存在 | 当作空目录 | 不报错，并输出提示 |
+| 外部图片 URL | 保留原 URL | 不校验 |
+| 本地封面不存在 | 警告并跳过封面 | 构建失败或由 `failOnMissing` 决定 |
+| 不支持的扩展名 | 跳过并提示 | 构建失败或由配置决定 |
+| 无法读取尺寸 | 保留图片，尺寸为空 | 警告，不阻断构建 |
+| 缺少 alt | 使用标题/文件名降级 | 输出可访问性警告 |
+
+插件必须避免把图片扫描错误吞掉后继续输出不完整的虚拟数据。对于严格模式，错误信息中应包含文章文件路径、原始图片路径和解析后的目标路径。
+
+## 十一、验收标准
+
+实现完成后至少验证以下场景：
+
+1. 不增加任何图片配置时，默认主题仍能成功构建；
+2. `public/images` 下的图片可以通过带 `base` 的 URL 访问；
+3. 文章目录中的相对封面路径可以正确解析；
+4. 不存在的本地图片能被发现并按 strict 配置处理；
+5. 首页文章列表能展示有封面的文章，并保持无封面文章布局正常；
+6. 图片的 `alt`、尺寸和说明文字不会丢失；
+7. 外部图片 URL 不会被错误地拼接站点 `base`；
+8. `virtual-images-data` 在空数据时仍有稳定的类型和运行时导出；
+9. 示例博客生产构建后，图片文件和 HTML 引用均存在；
+10. 运行 `pnpm run build:packages`、`pnpm --filter blog build` 和 `pnpm run check` 通过。
+
+## 十二、暂不处理的问题
+
+- 不在插件中上传图片或连接云存储；
+- 不自动生成图片内容，不接入 AI 图片生成；
+- 不在第一阶段重写所有 Markdown 图片节点；
+- 不在第一阶段扫描或复制文章局部图片；
+- 不默认引入重量级图片压缩依赖；
+- 不将图片生成独立页面；
+- 不把远程图片下载到本地；
+- 不修改现有文章的图片链接格式，除非路径校验证明确实需要兼容处理。
+
+## 十三、预期文件变更
+
+第一阶段实现预计涉及：
+
+```text
+plugins/images/
+├── src/
+│   ├── index.ts
+│   ├── plugin.ts
+│   ├── types.ts
+│   ├── utils.ts
+│   └── env.d.ts
+├── client.d.ts
+├── package.json
+├── rslib.config.ts
+├── tsconfig.json
+└── README.md
+
+packages/core/src/types.ts       # 增加 ImagesConfig 和 CogitaConfig.images
+packages/shared/src/index.ts     # 增加插件配置类型
+plugins/posts-frontmatter/src/* # 增加可选图片字段
+packages/ui/src/*                # 增加封面/图片展示组件和类型
+themes/lucid/src/*               # 注册插件并展示封面
+blog/public/images/*             # 示例图片资源
+blog/posts/*                     # 增加图片引用示例
+```
+
+## 十四、开放决策
+
+开始编码前需要确认以下实现细节：
+
+1. 第一阶段是否接受 `image`、`imageAlt`、`imageCaption` 三个 frontmatter 字段，还是只先做 `image`；
+2. 图片尺寸读取是否使用轻量的 `image-size`，还是直接为后续优化预留 `sharp`；
+3. 示例图片采用仓库内静态图片，还是使用 SVG/占位图以减少二进制资源；
+4. Lucid 首页是否默认展示封面，还是增加 `showCover` 主题配置后再开启；
+5. 是否把 `image` 字段直接并入 `PostFrontmatter`，让 RSS/SEO/搜索等后续插件共享。
+
+当前建议：采用前三个字段、使用轻量尺寸读取方案、先用仓库内 SVG/PNG 示例图、Lucid 默认展示封面，将 `image` 纳入文章公共数据模型，并让运行时图片数据只保留逻辑 URL 与展示元数据。

--- a/packages/core/src/node/config.ts
+++ b/packages/core/src/node/config.ts
@@ -190,6 +190,16 @@ function createFullConfig(cogitaConfig: CogitaConfig, root: string): CogitaFullC
           ...cogitaConfig.rss,
         }
       : undefined,
+    // 图片插件配置默认启用，确保主题可以安全导入虚拟图片模块
+    images: {
+      enabled: true,
+      dir: 'public/images',
+      extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg'],
+      readDimensions: true,
+      failOnMissing: cogitaConfig.strict !== false,
+      warnOnMissingAlt: false,
+      ...cogitaConfig.images,
+    },
   };
 }
 
@@ -213,6 +223,8 @@ export async function createRspressConfig(
     title: cogitaConfig.site?.title,
     description: cogitaConfig.site?.description,
     base: cogitaConfig.site?.base,
+    markdown: cogitaConfig.markdown,
+    mediumZoom: cogitaConfig.mediumZoom,
     themeConfig: cogitaConfig.themeConfig,
     builderConfig: cogitaConfig.builderConfig,
     plugins: [], // Will be populated next

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,8 @@ export type { CogitaTheme, LayoutProps };
 
 export type ThemeConfig = UserConfig['themeConfig'];
 export type BuilderConfig = UserConfig['builderConfig'];
+export type MarkdownConfig = UserConfig['markdown'];
+export type MediumZoomConfig = UserConfig['mediumZoom'];
 
 export interface SiteConfig {
   title?: string;
@@ -179,6 +181,24 @@ export interface RSSConfig {
   };
 }
 
+/**
+ * 图片插件配置。
+ */
+export interface ImagesConfig {
+  /** 是否启用图片元数据扫描。 */
+  enabled?: boolean;
+  /** 公共图片目录，相对于项目根目录。 */
+  dir?: string;
+  /** 扫描的图片扩展名，不含点号。 */
+  extensions?: string[];
+  /** 是否读取图片尺寸。 */
+  readDimensions?: boolean;
+  /** 找不到文章封面时是否让构建失败。 */
+  failOnMissing?: boolean;
+  /** 是否警告文章封面缺少明确的替代文本。 */
+  warnOnMissingAlt?: boolean;
+}
+
 export interface CogitaConfig {
   site?: SiteConfig;
   theme?: string;
@@ -202,6 +222,15 @@ export interface CogitaConfig {
    * RSS feed configuration
    */
   rss?: RSSConfig;
+
+  /** 图片公共资源与文章封面配置。 */
+  images?: ImagesConfig;
+
+  /** Rspress Markdown 配置。 */
+  markdown?: MarkdownConfig;
+
+  /** Rspress 原生图片放大配置。 */
+  mediumZoom?: MediumZoomConfig;
 
   /**
    * Rspress theme config

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,16 @@ export interface CogitaPluginConfig {
     routePrefix?: string;
     extensions?: string[];
   };
+  images?: {
+    enabled?: boolean;
+    dir?: string;
+    extensions?: string[];
+    readDimensions?: boolean;
+    failOnMissing?: boolean;
+    warnOnMissingAlt?: boolean;
+  };
+  markdown?: UserConfig['markdown'];
+  mediumZoom?: UserConfig['mediumZoom'];
   rss?: {
     title?: string;
     description?: string;
@@ -75,7 +85,7 @@ export interface CogitaPluginConfig {
   [key: string]: unknown;
 }
 
-// A plugin factory function that receives the final config and returns a Rspress plugin.
+// 插件工厂函数接收最终配置并返回 Rspress 插件。
 export type CogitaPluginFactory = (
   config: CogitaPluginConfig
 ) => RspressPlugin | RspressPlugin[] | null | undefined;

--- a/packages/ui/src/components/PostCover/index.module.css
+++ b/packages/ui/src/components/PostCover/index.module.css
@@ -1,0 +1,21 @@
+.postCover {
+  margin: 0 0 1.25rem;
+  overflow: hidden;
+  border-radius: 6px;
+  background: var(--cogita-border-color, #f0f0f0);
+}
+
+.postCoverImage {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 18rem;
+  object-fit: cover;
+}
+
+.postCoverCaption {
+  padding: 0.5rem 0.75rem;
+  color: var(--cogita-text-color-secondary, #777777);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}

--- a/packages/ui/src/components/PostCover/index.tsx
+++ b/packages/ui/src/components/PostCover/index.tsx
@@ -1,0 +1,28 @@
+import { normalizeImagePath } from '@rspress/runtime';
+import type React from 'react';
+import styles from './index.module.css';
+
+export interface PostCoverProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * 渲染文章封面，并兼容 Rspress 的 base 配置。
+ */
+export const PostCover: React.FC<PostCoverProps> = ({ src, alt, caption, width, height }) => (
+  <figure className={styles.postCover}>
+    <img
+      className={styles.postCoverImage}
+      src={normalizeImagePath(src)}
+      alt={alt}
+      loading="lazy"
+      width={width}
+      height={height}
+    />
+    {caption && <figcaption className={styles.postCoverCaption}>{caption}</figcaption>}
+  </figure>
+);

--- a/packages/ui/src/components/PostList/index.tsx
+++ b/packages/ui/src/components/PostList/index.tsx
@@ -3,6 +3,7 @@ import { normalizeHrefInRuntime } from '@rspress/runtime';
 import { Link } from '@rspress/theme-default';
 import type React from 'react';
 import type { Post } from '../../types';
+import { PostCover } from '../PostCover';
 import { TagList } from '../TagList';
 import styles from './index.module.css';
 
@@ -20,13 +21,25 @@ export interface PostListProps {
    * Whether to show tags in post items
    */
   showTags?: boolean;
+  /** 是否在文章卡片中显示封面。 */
+  showCover?: boolean;
 }
 
-const DefaultPostItem: React.FC<{ post: Post; showTags?: boolean }> = ({
+const DefaultPostItem: React.FC<{ post: Post; showTags?: boolean; showCover?: boolean }> = ({
   post,
   showTags = true,
+  showCover = false,
 }) => (
   <article key={post.url} className={styles.postItem}>
+    {showCover && post.image && (
+      <PostCover
+        src={post.image}
+        alt={post.imageAlt || post.title}
+        caption={post.imageCaption}
+        width={post.imageWidth}
+        height={post.imageHeight}
+      />
+    )}
     <Link href={normalizeHrefInRuntime(post.route)}>
       <h2 className={styles.title}>{post.title}</h2>
       <time dateTime={post.updateDate} className={styles.date}>
@@ -44,14 +57,19 @@ const DefaultPostItem: React.FC<{ post: Post; showTags?: boolean }> = ({
   </article>
 );
 
-export const PostList: React.FC<PostListProps> = ({ posts, renderItem, showTags = true }) => {
+export const PostList: React.FC<PostListProps> = ({
+  posts,
+  renderItem,
+  showTags = true,
+  showCover = false,
+}) => {
   return (
     <div className={styles.postListContainer}>
       {posts.map((post) =>
         renderItem ? (
           renderItem(post)
         ) : (
-          <DefaultPostItem key={post.url} post={post} showTags={showTags} />
+          <DefaultPostItem key={post.url} post={post} showTags={showTags} showCover={showCover} />
         )
       )}
     </div>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/Button';
 export * from './components/PostList';
+export * from './components/PostCover';
 export * from './components/TagCloud';
 export * from './components/TagList';
 export * from './types';

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -7,5 +7,10 @@ export interface Post {
   updateDate: string;
   categories?: string[];
   tags?: string[];
+  image?: string;
+  imageAlt?: string;
+  imageCaption?: string;
+  imageWidth?: number;
+  imageHeight?: number;
   url: string;
 }

--- a/plugins/images/README.md
+++ b/plugins/images/README.md
@@ -1,0 +1,31 @@
+# @cogita/plugin-images
+
+为 Cogita 提供公共图片清单、文章封面校验、使用统计和 `virtual-images-data` 运行时模块。
+
+第一阶段只扫描项目 `public/images` 下的图片。文章 frontmatter 可以使用：
+
+```yaml
+image: /images/example.png
+imageAlt: 示例图片
+imageCaption: 图片说明
+```
+
+Markdown 正文中的相对图片仍由 Rspress 原生处理。
+
+二期 A 增加了可选的封面可访问性提示和使用关系索引：
+
+```ts
+images: {
+  warnOnMissingAlt: true,
+}
+```
+
+运行时可以从 `virtual-images-data` 读取 `imageUsage`，并通过 `getUnusedImages()` 找到没有被文章封面引用的公共图片。正文图片的 `figure`、说明文字和 lightbox 交互仍属于后续阶段。
+
+Rspress 已内置图片放大能力，Cogita 通过顶层 `mediumZoom` 配置透传其选择器和选项，不在图片插件中重复引入交互依赖：
+
+```ts
+mediumZoom: {
+  selector: '.rspress-doc p > img',
+}
+```

--- a/plugins/images/client.d.ts
+++ b/plugins/images/client.d.ts
@@ -1,0 +1,27 @@
+declare module 'virtual-images-data' {
+  export interface ImageData {
+    src: string;
+    relativePath?: string;
+    name?: string;
+    extension?: string;
+    width?: number;
+    height?: number;
+    alt?: string;
+    caption?: string;
+    source: 'public' | 'external';
+    postRoute?: string;
+  }
+
+  export interface ImageUsage {
+    src: string;
+    count: number;
+    postRoutes: string[];
+  }
+
+  export const allImages: ImageData[];
+  export const postCovers: Record<string, ImageData>;
+  export const imageUsage: Record<string, ImageUsage>;
+  export function getImageBySrc(src: string): ImageData | undefined;
+  export function getPostCover(route: string): ImageData | undefined;
+  export function getUnusedImages(): ImageData[];
+}

--- a/plugins/images/package.json
+++ b/plugins/images/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@cogita/plugin-images",
+  "version": "0.1.0",
+  "description": "公共图片清单与文章封面元数据插件。",
+  "keywords": ["cogita", "plugin", "images", "cover", "virtual-module", "rspress"],
+  "author": "wu9o <https://github.com/wu9o>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wu9o/cogita.git",
+    "directory": "plugins/images"
+  },
+  "bugs": {
+    "url": "https://github.com/wu9o/cogita/issues"
+  },
+  "homepage": "https://github.com/wu9o/cogita/tree/main/plugins/images#readme",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "client.d.ts", "README.md", "LICENSE"],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "rslib build",
+    "dev": "rslib build -w",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@rspress/core": "^1.45.1",
+    "glob": "^11.0.0",
+    "image-size": "^2.0.2"
+  },
+  "devDependencies": {
+    "@cogita/config": "workspace:*",
+    "@cogita/plugin-posts-frontmatter": "workspace:*",
+    "@cogita/shared": "workspace:*",
+    "@rslib/core": "0.11.2",
+    "@types/node": "^18.11.17",
+    "rsbuild-plugin-publint": "^0.3.3",
+    "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "@cogita/plugin-posts-frontmatter": "workspace:*"
+  }
+}

--- a/plugins/images/rslib.config.ts
+++ b/plugins/images/rslib.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
+
+export default defineConfig({
+  lib: [
+    {
+      bundle: false,
+      dts: true,
+      format: 'esm',
+      output: {
+        distPath: {
+          root: './dist',
+        },
+      },
+    },
+  ],
+  plugins: [pluginPublint()],
+});

--- a/plugins/images/src/index.ts
+++ b/plugins/images/src/index.ts
@@ -1,0 +1,8 @@
+export { pluginImages } from './plugin';
+export type {
+  ImageData,
+  ImageSource,
+  ImageUsage,
+  ResolvedImage,
+  ResolvedImagesConfig,
+} from './types';

--- a/plugins/images/src/plugin.ts
+++ b/plugins/images/src/plugin.ts
@@ -1,0 +1,204 @@
+import { cp, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { PostFrontmatter } from '@cogita/plugin-posts-frontmatter';
+import { getFrontmatterFromFile } from '@cogita/plugin-posts-frontmatter';
+import type { CogitaPluginConfig } from '@cogita/shared';
+import type { RspressPlugin } from '@rspress/core';
+import { glob } from 'glob';
+import type { ImageData, ImageUsage, ResolvedImage, ResolvedImagesConfig } from './types';
+import {
+  createExternalImage,
+  isExternalImageSource,
+  normalizeImageSrc,
+  normalizeImagesConfig,
+  readImageDimensions,
+  resolvePublicImagePath,
+  stripImageSuffix,
+  toRuntimeImage,
+} from './utils';
+
+function createRuntimeModule(
+  allImages: ImageData[],
+  postCovers: Record<string, ImageData>,
+  imageUsage: Record<string, ImageUsage>
+): string {
+  return [
+    `export const allImages = ${JSON.stringify(allImages)};`,
+    `export const postCovers = ${JSON.stringify(postCovers)};`,
+    `export const imageUsage = ${JSON.stringify(imageUsage)};`,
+    'export function getImageBySrc(src) {',
+    '  return allImages.find((image) => image.src === src);',
+    '}',
+    'export function getPostCover(route) {',
+    '  return postCovers[route];',
+    '}',
+    'export function getUnusedImages() {',
+    '  return allImages.filter((image) => !imageUsage[image.src]);',
+    '}',
+  ].join('\n');
+}
+
+async function scanPublicImages(
+  root: string,
+  imageConfig: ResolvedImagesConfig
+): Promise<ResolvedImage[]> {
+  const directory = path.resolve(root, imageConfig.dir);
+  const extensionPattern =
+    imageConfig.extensions.length > 1
+      ? `{${imageConfig.extensions.join(',')}}`
+      : imageConfig.extensions[0];
+  const files = await glob(`**/*.${extensionPattern}`, {
+    absolute: true,
+    cwd: directory,
+    nodir: true,
+  });
+
+  return files.map((filePath) => {
+    const image = resolvePublicImagePath(root, imageConfig.dir, filePath);
+    if (imageConfig.readDimensions) {
+      Object.assign(image, readImageDimensions(filePath));
+    }
+    return image;
+  });
+}
+
+function getPostCover(
+  post: PostFrontmatter,
+  imageBySrc: Map<string, ResolvedImage>
+): ImageData | null {
+  const reference = post.image?.trim();
+  if (!reference) {
+    return null;
+  }
+
+  if (isExternalImageSource(reference)) {
+    return createExternalImage(reference, post.imageAlt || post.title, post.imageCaption);
+  }
+
+  const source = imageBySrc.get(normalizeImageSrc(reference));
+  if (!source) {
+    return null;
+  }
+
+  return toRuntimeImage(source, {
+    alt: post.imageAlt || post.title,
+    caption: post.imageCaption,
+    postRoute: post.route,
+  });
+}
+
+async function scanPostFrontmatter(config: CogitaPluginConfig): Promise<PostFrontmatter[]> {
+  const postsConfig = config.posts ?? {};
+  const postsDir = postsConfig.dir || 'posts';
+  const routePrefix = postsConfig.routePrefix || 'posts';
+  const extensions = postsConfig.extensions?.length ? postsConfig.extensions : ['md', 'mdx'];
+  const extensionPattern = extensions.length > 1 ? `{${extensions.join(',')}}` : extensions[0];
+  const files = await glob(`${postsDir}/**/*.${extensionPattern}`, {
+    absolute: true,
+    cwd: config.cwd,
+    nodir: true,
+  });
+
+  return files
+    .map((filePath) => getFrontmatterFromFile(filePath, postsDir, routePrefix))
+    .filter((post): post is PostFrontmatter => post !== null);
+}
+
+async function copyPublicImages(
+  root: string,
+  imageDir: string,
+  rspressConfig: { outDir?: string; root?: string }
+): Promise<void> {
+  const sourceDir = path.resolve(root, imageDir);
+  const publicRoot = path.resolve(root, 'public');
+  const relativeToPublic = path.relative(publicRoot, sourceDir);
+  const outputRoot = path.resolve(rspressConfig.root || root, rspressConfig.outDir || 'doc_build');
+  const outputDir = path.resolve(outputRoot, relativeToPublic);
+
+  await mkdir(outputDir, { recursive: true });
+  await cp(sourceDir, outputDir, { recursive: true, force: true });
+}
+
+export function pluginImages(config: CogitaPluginConfig): RspressPlugin {
+  const imageConfig = normalizeImagesConfig(config);
+  let allImages: ImageData[] = [];
+  let postCovers: Record<string, ImageData> = {};
+  let imageUsage: Record<string, ImageUsage> = {};
+
+  return {
+    name: '@cogita/plugin-images',
+
+    async beforeBuild() {
+      allImages = [];
+      postCovers = {};
+      imageUsage = {};
+
+      if (!imageConfig.enabled) {
+        return;
+      }
+
+      const scannedImages = await scanPublicImages(config.root, imageConfig);
+      allImages = scannedImages.map((image) => toRuntimeImage(image));
+      const imageBySrc = new Map(
+        scannedImages.map((image) => [normalizeImageSrc(stripImageSuffix(image.src)), image])
+      );
+      const posts = await scanPostFrontmatter(config);
+      const missingCovers: string[] = [];
+      const missingAlt: string[] = [];
+
+      for (const post of posts) {
+        if (post.image && !post.imageAlt?.trim()) {
+          missingAlt.push(`${post.route} -> ${post.image}`);
+        }
+
+        const cover = getPostCover(post, imageBySrc);
+        if (!post.image) {
+          continue;
+        }
+        if (!cover) {
+          missingCovers.push(`${post.route} -> ${post.image}`);
+          continue;
+        }
+        postCovers[post.route] = cover;
+
+        const usage = imageUsage[cover.src] ?? {
+          src: cover.src,
+          count: 0,
+          postRoutes: [],
+        };
+        usage.count += 1;
+        usage.postRoutes.push(post.route);
+        imageUsage[cover.src] = usage;
+      }
+
+      if (missingCovers.length > 0) {
+        const message = `[Images Plugin] 找不到文章封面：\n${missingCovers.join('\n')}`;
+        if (imageConfig.failOnMissing) {
+          throw new Error(message);
+        }
+        console.warn(message);
+      }
+
+      if (imageConfig.warnOnMissingAlt && missingAlt.length > 0) {
+        console.warn(`[Images Plugin] 文章封面缺少明确的 alt 文本：\n${missingAlt.join('\n')}`);
+      }
+
+      console.log(
+        `[Images Plugin] 成功处理 ${allImages.length} 张公共图片，${Object.keys(postCovers).length} 个文章封面，${Object.keys(imageUsage).length} 张图片有封面引用`
+      );
+    },
+
+    async afterBuild(rspressConfig, isProd) {
+      if (!imageConfig.enabled || !isProd || allImages.length === 0) {
+        return;
+      }
+      await copyPublicImages(config.root, imageConfig.dir, rspressConfig);
+    },
+
+    addRuntimeModules() {
+      return {
+        'virtual-images-data': createRuntimeModule(allImages, postCovers, imageUsage),
+      };
+    },
+  };
+}

--- a/plugins/images/src/types.ts
+++ b/plugins/images/src/types.ts
@@ -1,0 +1,37 @@
+export type ImageSource = 'public' | 'external';
+
+/** 记录图片作为文章封面时的使用关系。 */
+export interface ImageUsage {
+  src: string;
+  count: number;
+  postRoutes: string[];
+}
+
+/** 暴露给主题和运行时代码的图片数据，不包含本地绝对路径。 */
+export interface ImageData {
+  src: string;
+  relativePath?: string;
+  name?: string;
+  extension?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+  caption?: string;
+  source: ImageSource;
+  postRoute?: string;
+}
+
+/** 图片插件配置的完整默认值。 */
+export interface ResolvedImagesConfig {
+  enabled: boolean;
+  dir: string;
+  extensions: string[];
+  readDimensions: boolean;
+  failOnMissing: boolean;
+  warnOnMissingAlt: boolean;
+}
+
+/** 构建阶段使用的图片数据，运行时不会泄漏 filePath。 */
+export interface ResolvedImage extends ImageData {
+  filePath: string;
+}

--- a/plugins/images/src/utils.ts
+++ b/plugins/images/src/utils.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { CogitaPluginConfig } from '@cogita/shared';
+import { imageSize } from 'image-size';
+import type { ImageData, ResolvedImage, ResolvedImagesConfig } from './types';
+
+const DEFAULT_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg'];
+
+/** 统一图片插件配置，避免插件直接依赖未归一化的用户输入。 */
+export function normalizeImagesConfig(config: CogitaPluginConfig): ResolvedImagesConfig {
+  const configured = config.images ?? {};
+  const extensions = configured.extensions?.length ? configured.extensions : DEFAULT_EXTENSIONS;
+
+  return {
+    enabled: configured.enabled !== false,
+    dir: configured.dir || 'public/images',
+    extensions: extensions.map((extension) => extension.replace(/^\./, '').toLowerCase()),
+    readDimensions: configured.readDimensions !== false,
+    failOnMissing: configured.failOnMissing ?? config.strict !== false,
+    warnOnMissingAlt: configured.warnOnMissingAlt === true,
+  };
+}
+
+/** 将操作系统路径转换为跨平台的 URL 路径。 */
+export function toPosixPath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+/** 判断 frontmatter 中的值是否为可直接使用的外部图片地址。 */
+export function isExternalImageSource(value: string): boolean {
+  return /^(?:https?:|data:|\/\/)/i.test(value);
+}
+
+/**
+ * 将 public 目录中的文件转换为站点运行时使用的图片数据。
+ */
+export function toRuntimeImage(
+  image: ResolvedImage,
+  overrides: Pick<ImageData, 'alt' | 'caption' | 'postRoute'> = {}
+): ImageData {
+  return {
+    src: image.src,
+    relativePath: image.relativePath,
+    name: image.name,
+    extension: image.extension,
+    width: image.width,
+    height: image.height,
+    alt: overrides.alt ?? image.alt,
+    caption: overrides.caption ?? image.caption,
+    source: image.source,
+    postRoute: overrides.postRoute ?? image.postRoute,
+  };
+}
+
+/**
+ * 读取常见图片尺寸。尺寸读取失败不会阻止图片本身被使用。
+ */
+export function readImageDimensions(filePath: string): Pick<ImageData, 'width' | 'height'> {
+  try {
+    const dimensions = imageSize(fs.readFileSync(filePath));
+    return {
+      width: typeof dimensions.width === 'number' ? dimensions.width : undefined,
+      height: typeof dimensions.height === 'number' ? dimensions.height : undefined,
+    };
+  } catch (error) {
+    console.warn(`[Images Plugin] 无法读取图片尺寸 ${filePath}:`, error);
+    return {};
+  }
+}
+
+/**
+ * 解析公共图片目录，确保图片最终能由 Rspress 的 public 资源规则提供服务。
+ */
+export function resolvePublicImagePath(root: string, dir: string, filePath: string): ResolvedImage {
+  const publicRoot = path.resolve(root, 'public');
+  const relativeToPublic = path.relative(publicRoot, filePath);
+
+  if (relativeToPublic.startsWith('..') || path.isAbsolute(relativeToPublic)) {
+    throw new Error(`图片目录必须位于 public 目录内：${dir}`);
+  }
+
+  const relativePath = toPosixPath(path.relative(root, filePath));
+  const src = `/${toPosixPath(relativeToPublic).replace(/^\/+/, '')}`;
+  const extension = path.extname(filePath).replace(/^\./, '').toLowerCase();
+
+  return {
+    filePath,
+    src,
+    relativePath,
+    name: path.basename(filePath, path.extname(filePath)),
+    extension,
+    source: 'public',
+  };
+}
+
+/** 去掉 URL 查询参数和哈希，用于和扫描得到的公共图片建立索引。 */
+export function stripImageSuffix(value: string): string {
+  return value.split(/[?#]/, 1)[0];
+}
+
+/** 从站点绝对路径中规范化出图片索引键。 */
+export function normalizeImageSrc(value: string): string {
+  const withoutSuffix = stripImageSuffix(value.trim());
+  return `/${withoutSuffix.replace(/^\/+/, '')}`;
+}
+
+/** 将外部图片地址转换为运行时图片数据。 */
+export function createExternalImage(src: string, alt?: string, caption?: string): ImageData {
+  return {
+    src,
+    alt,
+    caption,
+    source: 'external',
+  };
+}

--- a/plugins/images/tsconfig.json
+++ b/plugins/images/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/posts-frontmatter/src/plugin.ts
+++ b/plugins/posts-frontmatter/src/plugin.ts
@@ -69,7 +69,7 @@ export function pluginPostsFrontmatter(config: CogitaPluginConfig): RspressPlugi
       // 4. 遍历 allPostsData，为每篇文章添加一个页面路由
       return allPostsData.map((post) => ({
         routePath: post.route,
-        content: '---npageType: homen---',
+        content: '---\npageType: home\n---',
         filepath: post.filePath,
       }));
     },

--- a/plugins/posts-frontmatter/src/types.ts
+++ b/plugins/posts-frontmatter/src/types.ts
@@ -16,6 +16,12 @@ export interface PostFrontmatter {
   order?: number;
   /** 合集内的自定义标题（可选，覆盖文章原标题） */
   collectionTitle?: string;
+  /** 文章封面路径或外部图片地址 */
+  image?: string;
+  /** 文章封面替代文本 */
+  imageAlt?: string;
+  /** 文章封面说明文字 */
+  imageCaption?: string;
   url: string;
 }
 

--- a/plugins/posts-frontmatter/src/utils.ts
+++ b/plugins/posts-frontmatter/src/utils.ts
@@ -45,6 +45,9 @@ export function getFrontmatterFromFile(
       collection: frontmatter.collection,
       order: frontmatter.order,
       collectionTitle: frontmatter.collectionTitle,
+      image: frontmatter.image,
+      imageAlt: frontmatter.imageAlt,
+      imageCaption: frontmatter.imageCaption,
       url: '',
     };
   } catch (e) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,40 @@ importers:
         specifier: ^5.0.4
         version: 5.9.2
 
+  plugins/images:
+    dependencies:
+      '@rspress/core':
+        specifier: ^1.45.1
+        version: 1.45.1(webpack@5.101.2)
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.3
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
+    devDependencies:
+      '@cogita/config':
+        specifier: workspace:*
+        version: link:../../scripts/config
+      '@cogita/plugin-posts-frontmatter':
+        specifier: workspace:*
+        version: link:../posts-frontmatter
+      '@cogita/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@rslib/core':
+        specifier: 0.11.2
+        version: 0.11.2(@microsoft/api-extractor@7.52.10(@types/node@18.19.123))(typescript@5.9.2)
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.19.123
+      rsbuild-plugin-publint:
+        specifier: ^0.3.3
+        version: 0.3.3(@rsbuild/core@1.4.15)
+      typescript:
+        specifier: ^5.0.4
+        version: 5.9.2
+
   plugins/posts-frontmatter:
     dependencies:
       '@rspress/core':
@@ -325,6 +359,9 @@ importers:
       '@cogita/plugin-collections':
         specifier: workspace:*
         version: link:../../plugins/collections
+      '@cogita/plugin-images':
+        specifier: workspace:*
+        version: link:../../plugins/images
       '@cogita/plugin-posts-frontmatter':
         specifier: workspace:*
         version: link:../../plugins/posts-frontmatter
@@ -1410,6 +1447,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -2110,6 +2148,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -2134,6 +2173,7 @@ packages:
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -2237,6 +2277,11 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   immutable@5.1.3:
     resolution: {integrity: sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==}
@@ -5983,6 +6028,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  image-size@2.0.2: {}
 
   immutable@5.1.3: {}
 

--- a/themes/lucid/package.json
+++ b/themes/lucid/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@cogita/plugin-collections": "workspace:*",
+    "@cogita/plugin-images": "workspace:*",
     "@cogita/plugin-posts-frontmatter": "workspace:*",
     "@cogita/plugin-rss": "workspace:*",
     "@cogita/plugin-tags": "workspace:*",

--- a/themes/lucid/src/index.ts
+++ b/themes/lucid/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pluginCollections } from '@cogita/plugin-collections';
+import { pluginImages } from '@cogita/plugin-images';
 import { pluginPostsFrontmatter } from '@cogita/plugin-posts-frontmatter';
 import { pluginRSS } from '@cogita/plugin-rss';
 import { pluginTags } from '@cogita/plugin-tags';
@@ -56,6 +57,9 @@ export function getThemeConfig(): CogitaTheme {
     plugins: [
       // Posts 元数据处理插件
       pluginPostsFrontmatter,
+
+      // 公共图片清单与文章封面元数据插件
+      pluginImages,
 
       // RSS feed 生成插件
       pluginRSS,

--- a/themes/lucid/src/layouts/Home.tsx
+++ b/themes/lucid/src/layouts/Home.tsx
@@ -3,6 +3,7 @@ import { PostList, TagCloud } from '@cogita/ui';
 import { usePageData } from '@rspress/runtime';
 import type React from 'react';
 import { allCollections } from 'virtual-collections-data';
+import { postCovers } from 'virtual-images-data';
 import { allPosts } from 'virtual-posts-data';
 import { allTags, tagsConfig } from 'virtual-tags-data';
 
@@ -16,6 +17,19 @@ import { allTags, tagsConfig } from 'virtual-tags-data';
 const HomeLayout: React.FC<LayoutProps> = () => {
   const pageData = usePageData();
   const base = (pageData?.siteData?.base || '').replace(/\/$/, '');
+  const postsWithCovers = allPosts.map((post) => {
+    const cover = postCovers[post.route];
+    return cover
+      ? {
+          ...post,
+          image: cover.src,
+          imageAlt: cover.alt,
+          imageCaption: cover.caption,
+          imageWidth: cover.width,
+          imageHeight: cover.height,
+        }
+      : post;
+  });
 
   return (
     <div className="home-layout">
@@ -49,7 +63,7 @@ const HomeLayout: React.FC<LayoutProps> = () => {
             <h1 className="blog-title">最新文章</h1>
             <p className="blog-subtitle">记录编码、创造与思考的瞬间</p>
           </header>
-          <PostList posts={allPosts} showTags={true} />
+          <PostList posts={postsWithCovers} showTags={true} showCover={true} />
         </main>
       </div>
     </div>

--- a/themes/lucid/src/theme.css
+++ b/themes/lucid/src/theme.css
@@ -97,6 +97,29 @@
   min-width: 0;
 }
 
+/* 正文图片统一使用居中、圆角和轻量阴影，保留 Rspress 的放大交互。 */
+.rspress-doc p:has(> img:only-child),
+.rspress-doc figure.cogita-image-figure {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.rspress-doc p:has(> img:only-child) > img,
+.rspress-doc figure.cogita-image-figure > img {
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(15, 23, 42, 0.12);
+  cursor: zoom-in;
+}
+
+.rspress-doc figure.cogita-image-figure figcaption {
+  margin-top: 0.75rem;
+  color: var(--cogita-text-color-secondary);
+  font-size: 0.875rem;
+}
+
 /* 首页特定样式 */
 .home-layout {
   max-width: 1400px;

--- a/themes/lucid/src/types.d.ts
+++ b/themes/lucid/src/types.d.ts
@@ -8,11 +8,44 @@ declare module 'virtual-posts-data' {
     updateDate: string;
     description?: string;
     tags?: string[];
+    image?: string;
+    imageAlt?: string;
+    imageCaption?: string;
+    imageWidth?: number;
+    imageHeight?: number;
     url: string;
     filePath: string; // 添加缺失的字段
   }
 
   export const allPosts: Post[];
+}
+
+declare module 'virtual-images-data' {
+  interface ImageData {
+    src: string;
+    relativePath?: string;
+    name?: string;
+    extension?: string;
+    width?: number;
+    height?: number;
+    alt?: string;
+    caption?: string;
+    source: 'public' | 'external';
+    postRoute?: string;
+  }
+
+  interface ImageUsage {
+    src: string;
+    count: number;
+    postRoutes: string[];
+  }
+
+  export const allImages: ImageData[];
+  export const postCovers: Record<string, ImageData>;
+  export const imageUsage: Record<string, ImageUsage>;
+  export function getImageBySrc(src: string): ImageData | undefined;
+  export function getPostCover(route: string): ImageData | undefined;
+  export function getUnusedImages(): ImageData[];
 }
 
 declare module 'virtual-tags-data' {


### PR DESCRIPTION
## 概要

新增 @cogita/plugin-images，完成图片资源、文章封面和正文图片体验的第一阶段及二期基础能力。

## 主要变更

- 扫描 public/images，读取图片尺寸并校验文章封面路径。
- 支持 image、imageAlt、imageCaption frontmatter 字段。
- 通过 virtual-images-data 暴露图片清单、文章封面、使用统计和未使用图片查询。
- Lucid 首页文章卡片支持封面展示。
- 透传 Rspress 原生 mediumZoom，并增加正文图片基础样式。
- 增加缺少封面 alt 的非阻断告警。
- 同步插件设计文档、README、Roadmap 和 changeset。

## 验证

- pnpm run build:packages
- pnpm --filter blog build
- pnpm run check
- 本地浏览器验证正文图片加载和放大交互正常。